### PR TITLE
[fix] Remove assumption of parameter availability (config provided)

### DIFF
--- a/lib/sfn/command_module/stack.rb
+++ b/lib/sfn/command_module/stack.rb
@@ -115,7 +115,7 @@ module Sfn
             end
             if(config.get(:parameters))
               config.set(:parameters,
-                config.get(:parameters).merge(config[:parameter])
+                config.get(:parameters).merge(config.fetch(:parameter, Smash.new))
               )
             else
               config.set(:parameters, config.fetch(:parameter, Smash.new))


### PR DESCRIPTION
Fixes issue described in #20 where parameters is provided via
configuration resulting in merge where parameter would not be set