### PR TITLE
Ensure pathselector does not prefix template path when absolute

### DIFF
--- a/lib/sfn/utils/path_selector.rb
+++ b/lib/sfn/utils/path_selector.rb
@@ -1,4 +1,5 @@
 require 'sfn'
+require 'pathname'
 
 module Sfn
   module Utils
@@ -87,6 +88,8 @@ module Sfn
             entry = valid[response.to_i]
             if(entry[:type] == :directory)
               prompt_for_file(entry[:path], opts)
+            elsif Pathname(entry[:path]).absolute?
+              entry[:path]
             else
               "/#{entry[:path]}"
             end


### PR DESCRIPTION
Mayhaps I'm doing this wrong, but using the following .sfn configuration statement in the root of my repo, sfn fails to load the template due to an extra prefixing /.

base_directory File.join(File.dirname(__FILE__), 'sparkleformation')
