### PR TITLE
fixed a couple of typos in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ Supported formats:
 * YAML
 * JSON
 * XML
-n
+
 The configuration is contained within a file named
 `.sfn`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,7 +92,7 @@ end
 
 The default nesting functionality is `"deep"`. To learn more about
 the nesting functionality please refer to the [SparkleFormation nested
-stacks][nested_stacks] documentation.
+stacks][nested-stacks] documentation.
 
 When using nested stacks, a bucket is required for storage of the
 nested stack templates. `sfn` will automatically store nested templates


### PR DESCRIPTION
A total of three characters affected \o/

Glad I could help :)