### PR TITLE
Parameter context and URL name generation

### DIFF
--- a/lib/sfn/command_module/stack.rb
+++ b/lib/sfn/command_module/stack.rb
@@ -123,7 +123,7 @@ module Sfn
             stack_parameters = sparkle.fetch('Parameters', Smash.new)
           end
           unless(stack_parameters.empty?)
-            ui.info "#{ui.color('Stack runtime parameters:', :bold)} - template: #{ui.color(sparkle.root_path.map(&:name).join(' > '), :green, :bold)}"
+            ui.info "#{ui.color('Stack runtime parameters:', :bold)} - template: #{ui.color(sparkle.root_path.map(&:name).map(&:to_s).join(' > '), :green, :bold)}"
             if(config.get(:parameter).is_a?(Array))
               config[:parameter] = Smash[
                 *config.get(:parameter).map(&:to_a).flatten

--- a/lib/sfn/command_module/stack.rb
+++ b/lib/sfn/command_module/stack.rb
@@ -123,6 +123,7 @@ module Sfn
             stack_parameters = sparkle.fetch('Parameters', Smash.new)
           end
           unless(stack_parameters.empty?)
+            ui.info "#{ui.color('Stack runtime parameters:', :bold)} - template: #{ui.color(sparkle.root_path.map(&:name).join(' > '), :green, :bold)}"
             if(config.get(:parameter).is_a?(Array))
               config[:parameter] = Smash[
                 *config.get(:parameter).map(&:to_a).flatten


### PR DESCRIPTION
Provides template location context when populating parameters which is
useful when using a deeply nested structure. Updates the way bucket
object keys are generated for storing nested templates to use full path
nesting names. Using the full path naming prevents name collisions where
multiple stacks in different trees may have the same logical resource ID.