### PR TITLE
avoid printing compile time parameters ui message when using --print-only

### DIFF
--- a/lib/sfn/command_module/template.rb
+++ b/lib/sfn/command_module/template.rb
@@ -139,7 +139,7 @@ module Sfn
                 if(formation.compile_state)
                   current_state = current_state.merge(formation.compile_state)
                 end
-                ui.info "#{ui.color('Compile time parameters:', :bold)} - template: #{ui.color(pathed_name, :green, :bold)}" unless(config[:print_only])
+                ui.info "#{ui.color('Compile time parameters:', :bold)} - template: #{ui.color(pathed_name, :green, :bold)}" unless config[:print_only]
                 formation.parameters.each do |k,v|
                   current_state[k] = request_compile_parameter(k, v, current_state[k], !!formation.parent)
                 end

--- a/lib/sfn/command_module/template.rb
+++ b/lib/sfn/command_module/template.rb
@@ -139,7 +139,7 @@ module Sfn
                 if(formation.compile_state)
                   current_state = current_state.merge(formation.compile_state)
                 end
-                ui.info "#{ui.color('Compile time parameters:', :bold)} - template: #{ui.color(pathed_name, :green, :bold)}"
+                ui.info "#{ui.color('Compile time parameters:', :bold)} - template: #{ui.color(pathed_name, :green, :bold)}" unless(config[:print_only])
                 formation.parameters.each do |k,v|
                   current_state[k] = request_compile_parameter(k, v, current_state[k], !!formation.parent)
                 end


### PR DESCRIPTION
for 1.0 line