### PR TITLE
Only use root_path if handling a sparkle instance (deep nest)

### DIFF
--- a/lib/sfn/command_module/stack.rb
+++ b/lib/sfn/command_module/stack.rb
@@ -123,7 +123,11 @@ module Sfn
             stack_parameters = sparkle.fetch('Parameters', Smash.new)
           end
           unless(stack_parameters.empty?)
-            ui.info "#{ui.color('Stack runtime parameters:', :bold)} - template: #{ui.color(sparkle.root_path.map(&:name).map(&:to_s).join(' > '), :green, :bold)}"
+            if(sparkle.is_a?(SparkleFormation))
+              ui.info "#{ui.color('Stack runtime parameters:', :bold)} - template: #{ui.color(sparkle.root_path.map(&:name).map(&:to_s).join(' > '), :green, :bold)}"
+            else
+              ui.info ui.color('Stack runtime parameters:', :bold)
+            end
             if(config.get(:parameter).is_a?(Array))
               config[:parameter] = Smash[
                 *config.get(:parameter).map(&:to_a).flatten


### PR DESCRIPTION
Addresses #61 by only providing template path context when deeply nested
as shallow nesting will retain all parameters within the root stack.