### PR TITLE
Add conf command. Fix knife command configuration.

### DIFF
--- a/lib/chef/knife/knife_plugin_seed.rb
+++ b/lib/chef/knife/knife_plugin_seed.rb
@@ -63,6 +63,7 @@ unless(defined?(Chef::Knife::CloudformationCreate))
             base[k]
           end.compact.first || {}
           cmd_config = cmd_config.to_smash
+
           reconfig = config.find_all do |k,v|
             !v.nil?
           end
@@ -73,9 +74,14 @@ unless(defined?(Chef::Knife::CloudformationCreate))
             end
             [k,v]
           end
-          config = Smash[reconfig]
-          cmd_config = cmd_config.deep_merge(config)
+          n_config = Smash[reconfig]
+          cmd_config = cmd_config.deep_merge(n_config)
           self.class.sfn_class.new(cmd_config, name_args).execute!
+        end
+
+        # NOOP this merge as it breaks expected state
+        def merge_configs
+          config
         end
 
       end

--- a/lib/sfn/command.rb
+++ b/lib/sfn/command.rb
@@ -4,6 +4,9 @@ require 'bogo-cli'
 module Sfn
   class Command < Bogo::Cli::Command
 
+    include CommandModule::Callbacks
+
+    autoload :Conf, 'sfn/command/conf'
     autoload :Create, 'sfn/command/create'
     autoload :Describe, 'sfn/command/describe'
     autoload :Destroy, 'sfn/command/destroy'

--- a/lib/sfn/command/conf.rb
+++ b/lib/sfn/command/conf.rb
@@ -1,0 +1,39 @@
+require 'sfn'
+
+module Sfn
+  class Command
+    # Config command
+    class Conf < Command
+
+      # Run the list command
+      def execute!
+        ui.info ui.color("Current configuration state:")
+        Config::Conf.attributes.sort_by(&:first).each do |k, val|
+          if(config.has_key?(k))
+            ui.print "  #{ui.color(k, :bold, :green)}: "
+            format_value(config[k], '  ')
+          end
+        end
+      end
+
+      def format_value(value, indent='')
+        if(value.is_a?(Hash))
+          ui.puts
+          value.sort_by(&:first).each do |k,v|
+            ui.print "#{indent}  #{ui.color(k, :bold)}: "
+            format_value(v, indent + '  ')
+          end
+        elsif(value.is_a?(Array))
+          ui.puts
+          value.map(&:to_s).sort.each do |v|
+            ui.print "#{indent}  "
+            format_value(v, indent + '  ')
+          end
+        else
+          ui.puts value.to_s
+        end
+      end
+
+    end
+  end
+end

--- a/lib/sfn/config.rb
+++ b/lib/sfn/config.rb
@@ -9,6 +9,7 @@ module Sfn
     # Only values allowed designating bool type
     BOOLEAN_VALUES = [TrueClass, FalseClass]
 
+    autoload :Conf, 'sfn/config/conf'
     autoload :Create, 'sfn/config/create'
     autoload :Describe, 'sfn/config/describe'
     autoload :Destroy, 'sfn/config/destroy'
@@ -67,6 +68,7 @@ module Sfn
       :description => 'Automatically accept any requests for confirmation'
     )
 
+    attribute :conf, Conf, :coerce => proc{|v| Conf.new(v)}
     attribute :create, Create, :coerce => proc{|v| Create.new(v)}
     attribute :update, Update, :coerce => proc{|v| Update.new(v)}
     attribute :destroy, Destroy, :coerce => proc{|v| Destroy.new(v)}

--- a/lib/sfn/config/conf.rb
+++ b/lib/sfn/config/conf.rb
@@ -1,0 +1,9 @@
+require 'sfn'
+
+module Sfn
+  class Config
+    # Config command configuration (subclass create to get all the configs)
+    class Conf < Create
+    end
+  end
+end


### PR DESCRIPTION
Adds command for displaying current configuration settings at runtime.
Fixes knife configuration setup to prevent defaults from stomping values
that should override.