### PR TITLE
Add compile time parameters options. Make hash types more consistent.

### DIFF
--- a/lib/sfn/config.rb
+++ b/lib/sfn/config.rb
@@ -42,7 +42,7 @@ module Sfn
           v
         end
       },
-      :description => 'Provider credentials'
+      :description => 'Provider credentials (CredentialName:CredentialValue)'
     )
     attribute(
       :ignore_parameters, String,

--- a/lib/sfn/config/update.rb
+++ b/lib/sfn/config/update.rb
@@ -29,17 +29,7 @@ module Sfn
       )
       attribute(
         :parameters, Smash,
-        :description => 'Pass template parameters directly (ParamName:ParamValue)',
-        :coerce => lambda{|v|
-          case v
-          when String
-            Smash[v.split(',').map{|x| v.split(/[=:]/, 2)}]
-          when Hash
-            v.to_smash
-          else
-            v
-          end
-        }
+        :description => 'Pass template parameters directly'
       )
       attribute(
         :plan, [TrueClass, FalseClass],
@@ -48,17 +38,7 @@ module Sfn
       )
       attribute(
         :compile_parameters, Smash,
-        :description => 'Pass template compile time parameters directly (ParamName:ParamValue)',
-        :coerce => lambda{|v|
-          case v
-          when String
-            Smash[v.split(',').map{|x| v.split(/[=:]/, 2)}]
-          when Hash
-            v.to_smash
-          else
-            v
-          end
-        }
+        :description => 'Pass template compile time parameters directly'
       )
 
     end

--- a/lib/sfn/config/update.rb
+++ b/lib/sfn/config/update.rb
@@ -13,15 +13,52 @@ module Sfn
       attribute(
         :parameter, Smash,
         :multiple => true,
+        :description => '[DEPRECATED - use `parameters`] Pass template parameters directly (ParamName:ParamValue)',
+        :coerce => lambda{|v, inst|
+          result = inst.data[:parameter] || Array.new
+          case v
+          when String
+            v.split(',').each do |item|
+              result.push(Smash[*item.split(/[=:]/, 2)])
+            end
+          else
+            result.push(v.to_smash)
+          end
+          {:bogo_multiple => result}
+        }
+      )
+      attribute(
+        :parameters, Smash,
         :description => 'Pass template parameters directly (ParamName:ParamValue)',
         :coerce => lambda{|v|
-          v.is_a?(String) ? Smash[*v.split(/[=:]/, 2)] : v
+          case v
+          when String
+            Smash[v.split(',').map{|x| v.split(/[=:]/, 2)}]
+          when Hash
+            v.to_smash
+          else
+            v
+          end
         }
       )
       attribute(
         :plan, [TrueClass, FalseClass],
         :default => true,
         :description => 'Provide planning information prior to update'
+      )
+      attribute(
+        :compile_parameters, Smash,
+        :description => 'Pass template compile time parameters directly (ParamName:ParamValue)',
+        :coerce => lambda{|v|
+          case v
+          when String
+            Smash[v.split(',').map{|x| v.split(/[=:]/, 2)}]
+          when Hash
+            v.to_smash
+          else
+            v
+          end
+        }
       )
 
     end


### PR DESCRIPTION
Make handling of hash type configurations more consistent when
re-formatting from CLI option. Deprecate the `:parameter` usage and add
a new `:parameters` option to properly make use of the underlying
implementation. Introduce new `:compile_parameters` option to allow
direct setting via CLI