### PR TITLE
do not blow up when path is called "Outputs"

### DIFF
--- a/lib/sfn/planner/aws.rb
+++ b/lib/sfn/planner/aws.rb
@@ -367,7 +367,7 @@ module Sfn
             end
           end
         elsif(path.start_with?('Outputs'))
-          set_resource(:outputs, results, path.split('.')[1], {:properties => []})
+          set_resource(:outputs, results, path.split('.').last, {:properties => []})
         end
       end
 

--- a/test/specs/sfn/planner/aws_spec.rb
+++ b/test/specs/sfn/planner/aws_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../../../helper'
+require 'sfn/planner/aws'
+
+describe Sfn::Planner::Aws do
+  it "does not blow up on Outputs keys" do
+    results = {:outputs => {}}
+    planner = Sfn::Planner::Aws.new(nil, nil, nil, nil)
+    planner.send(:register_diff, results, 'Outputs', {}, nil, {})
+    results.must_equal :outputs => {"Outputs" => {:properties => []}}
+  end
+end


### PR DESCRIPTION
this happened during update, diff worked fine, stack does not have outputs ... maybe that's the reason ... idk ... also no idea how to test that properly ...

@chrisroberts 

```
be sfn update hostgroup-xyz -f xyz.rb
[Sfn]: SparkleFormation: update
[Sfn]:   -> Name: hostgroup-xyz Path: pod/xyz.rb
PATH Outputs
ERROR: NoMethodError: undefined method `to_sym' for nil:NilClass
vendor/bundle/gems/hashie-3.4.3/lib/hashie/extensions/coercion.rb:87:in `key_coercion'
vendor/bundle/gems/hashie-3.4.3/lib/hashie/extensions/coercion.rb:30:in `set_value_with_coercion'
vendor/bundle/gems/sfn-1.1.16/lib/sfn/planner/aws.rb:386:in `set_resource'
podzilla/vendor/bundle/gems/sfn-1.1.16/lib/sfn/planner/aws.rb:371:in `register_diff'
podzilla/vendor/bundle/gems/sfn-1.1.16/lib/sfn/planner/aws.rb:302:in `block in run_stack_diff'
podzilla/vendor/bundle/gems/sfn-1.1.16/lib/sfn/planner/aws.rb:301:in `each'
podzilla/vendor/bundle/gems/sfn-1.1.16/lib/sfn/planner/aws.rb:301:in `run_stack_diff'
podzilla/vendor/bundle/gems/sfn-1.1.16/lib/sfn/planner/aws.rb:192:in `plan_stack'
podzilla/vendor/bundle/gems/sfn-1.1.16/lib/sfn/planner/aws.rb:134:in `generate_plan'
podzilla/vendor/bundle/gems/sfn-1.1.16/lib/sfn/command/update.rb:94:in `execute!'
podzilla/vendor/bundle/gems/sfn-1.1.16/bin/sfn:40:in `block (4 levels) in <top (required)>'
```