### PR TITLE
Only set output resource if name available within planner

### DIFF
--- a/lib/sfn/planner/aws.rb
+++ b/lib/sfn/planner/aws.rb
@@ -367,7 +367,13 @@ module Sfn
             end
           end
         elsif(path.start_with?('Outputs'))
-          set_resource(:outputs, results, path.split('.')[1], {:properties => []})
+          o_resource_name = path.split('.')[1]
+          if(o_resource_name)
+            set_resource(
+              :outputs, results, o_resource_name,
+              :properties => []
+            )
+          end
         end
       end
 


### PR DESCRIPTION
This addresses the issue described within PR #92. If no value is
available the resulting action should be a no-op.