### PR TITLE
run Bundler.require if using Bundler

### DIFF
--- a/bin/sfn
+++ b/bin/sfn
@@ -3,6 +3,10 @@
 require 'bogo-cli'
 require 'sfn'
 
+if(defined?(Bundler))
+  Bundler.require
+end
+
 Bogo::Cli::Setup.define do
 
   on :v, :version, 'Print version ' do


### PR DESCRIPTION
A temporary workaround to enable side-loading commands into sfn.