### PR TITLE
Remove deprecated capabilities flag

### DIFF
--- a/lib/sfn/config/create.rb
+++ b/lib/sfn/config/create.rb
@@ -17,12 +17,6 @@ module Sfn
         :short_flag => 'O'
       )
       attribute(
-        :capabilities, String,
-        :multiple => true,
-        :description => 'Capabilities to allow the stack',
-        :short_flag => 'B'
-      )
-      attribute(
         :options, Smash,
         :description => 'Extra options to apply to the API call',
         :short_flag => 'S'


### PR DESCRIPTION
The capabilities flag was an old flag that was replaced by
`--options` for provider specific create options. (re: #103)