### PR TITLE
Add init command for project initialization

### DIFF
--- a/lib/sfn/command.rb
+++ b/lib/sfn/command.rb
@@ -14,6 +14,7 @@ module Sfn
     autoload :Events, 'sfn/command/events'
     autoload :Export, 'sfn/command/export'
     autoload :Import, 'sfn/command/import'
+    autoload :Init, 'sfn/command/init'
     autoload :Inspect, 'sfn/command/inspect'
     autoload :List, 'sfn/command/list'
     autoload :Print, 'sfn/command/print'

--- a/lib/sfn/command/init.rb
+++ b/lib/sfn/command/init.rb
@@ -1,0 +1,57 @@
+require 'sfn'
+require 'fileutils'
+
+module Sfn
+  class Command
+    # Init command
+    class Init < Command
+
+      include Sfn::CommandModule::Base
+
+      INIT_DIRECTORIES = [
+        'sparkleformation/dynamics',
+        'sparkleformation/components',
+        'sparkleformation/registry'
+      ]
+
+      # Run the init command to initialize new project
+      def execute!
+        unless(name_args.size == 1)
+          raise ArgumentError.new 'Please provide path argument only for project initialization'
+        else
+          path = name_args.first
+        end
+        if(File.file?(path))
+          raise "Cannot create project directory. Given path is a file. (`#{path}`)"
+        end
+        if(File.directory?(path))
+          ui.warn "Project directory already exists at given path. (`#{path}`)"
+          ui.confirm 'Overwrite existing files?'
+        end
+        run_action 'Creating base project directories' do
+          INIT_DIRECTORIES.each do |new_dir|
+            FileUtils.mkdir_p(File.join(path, new_dir))
+          end
+          nil
+        end
+        run_action 'Creating project bundle' do
+          File.open(File.join(path, 'Gemfile'), 'w') do |file|
+            file.puts "source 'https://rubygems.org'\n\ngem 'sfn'"
+          end
+          nil
+        end
+        ui.info 'Generating .sfn configuration file'
+        Dir.chdir(path) do
+          Conf.new({:generate => true}, []).execute!
+        end
+        ui.info 'Installing project bundle'
+        Dir.chdir(path) do
+          Bundler.clean_system('bundle install')
+        end
+        ui.info 'Project initialization complete!'
+        ui.puts "  Project path -> #{File.expand_path(path)}"
+      end
+
+    end
+  end
+end

--- a/lib/sfn/config.rb
+++ b/lib/sfn/config.rb
@@ -45,6 +45,7 @@ module Sfn
     autoload :Events, 'sfn/config/events'
     autoload :Export, 'sfn/config/export'
     autoload :Import, 'sfn/config/import'
+    autoload :Init, 'sfn/config/init'
     autoload :Inspect, 'sfn/config/inspect'
     autoload :List, 'sfn/config/list'
     autoload :Print, 'sfn/config/print'

--- a/lib/sfn/config/init.rb
+++ b/lib/sfn/config/init.rb
@@ -1,0 +1,10 @@
+require 'sfn'
+
+module Sfn
+  class Config
+    # Init command configuration
+    class Init < Config
+
+    end
+  end
+end


### PR DESCRIPTION
Command adds support for automatic project initialization. Creates
required directories, runs `conf` command to install default generated
.sfn configuration file. Creates Gemfile for project bundle and installs
the project bundle. re: #101