### PR TITLE
Allow nested stack processing to be disabled

### DIFF
--- a/lib/sfn/command_module/template.rb
+++ b/lib/sfn/command_module/template.rb
@@ -179,6 +179,8 @@ module Sfn
                   process_nested_stack_deep(sf, c_stack)
                 when :shallow
                   process_nested_stack_shallow(sf, c_stack)
+                when :none
+                  sf.dump.merge('sfn_nested_stack' => !!sf.nested?)
                 else
                   raise ArgumentError.new "Unknown nesting style requested: #{config[:apply_nesting].inspect}!"
                 end


### PR DESCRIPTION
Addresses issue #111 to disable nested stack processing. Useful in situations
where a user wants to manually nest, or use a third party template.