### PR TITLE
aws_mfa callback - add missing require 'fileutils'

### DIFF
--- a/lib/sfn/callback/aws_mfa.rb
+++ b/lib/sfn/callback/aws_mfa.rb
@@ -1,4 +1,5 @@
 require 'sfn'
+require 'fileutils'
 
 module Sfn
   class Callback


### PR DESCRIPTION
Add ```require 'fileutils'``` to the aws_mfa callback, otherwise it can't write the credentials to the ```.sfn-aws``` file and gives an error: ```ERROR: NameError: uninitialized constant Sfn::Callback::AwsMfa::FileUtils```.