### PR TITLE
Fix compile time parameters from CLI

### DIFF
--- a/lib/sfn/command_module/template.rb
+++ b/lib/sfn/command_module/template.rb
@@ -145,8 +145,19 @@ module Sfn
               sf.compile_time_parameter_setter do |formation|
                 f_name = formation.root_path.map(&:name).map(&:to_s)
                 pathed_name = f_name.join(' > ')
-                f_name = f_name.join('_')
-                current_state = compile_state.fetch(f_name, Smash.new)
+                f_name = f_name.join('__')
+                current_state = compile_state[f_name]
+                unless(current_state)
+                  f_name = f_name.split('__')
+                  f_name.shift
+                  f_name = f_name.join('__')
+                  current_state = f_name.empty? ? compile_state : compile_state[f_name]
+                end
+                if(formation.root? && compile_state[f_name].nil?)
+                  current_state = compile_state
+                else
+                  current_state = compile_state.fetch(f_name, Smash.new)
+                end
                 if(formation.compile_state)
                   current_state = current_state.merge(formation.compile_state)
                 end

--- a/lib/sfn/config/update.rb
+++ b/lib/sfn/config/update.rb
@@ -40,11 +40,6 @@ module Sfn
         :description => 'Provide planning information prior to update',
         :short_flag => 'l'
       )
-      attribute(
-        :compile_parameters, Smash,
-        :description => 'Pass template compile time parameters directly',
-        :short_flag => 'o'
-      )
 
     end
   end

--- a/lib/sfn/config/validate.rb
+++ b/lib/sfn/config/validate.rb
@@ -72,6 +72,28 @@ module Sfn
         :coerce => lambda{|s| s.to_s},
         :short_flag => 's'
       )
+      attribute(
+        :compile_parameters, Smash,
+        :description => 'Pass template compile time parameters directly',
+        :short_flag => 'o',
+        :coerce => lambda{|v|
+          case v
+          when String
+            result = Smash.new
+            v.split(',').each do |item_pair|
+              key, value = item_pair.split(/[=:]/, 2)
+              key = key.split('__')
+              key = [key.pop, key.map{|x| Bogo::Utility.camel(x)}.join('__')].reverse
+              result.set(*key, value)
+            end
+            result
+          when Hash
+            v.to_smash
+          else
+            v
+          end
+        }
+      )
 
     end
   end


### PR DESCRIPTION
Properly build compile time parameters Hash on coercion. Allow
root stack name to be omitted. (#131)