### PR TITLE
Prevent internal artifacts from remaining within template content

### DIFF
--- a/lib/sfn/command/create.rb
+++ b/lib/sfn/command/create.rb
@@ -59,7 +59,7 @@ module Sfn
           )
 
           apply_stacks!(stack)
-          stack.template = Sfn::Utils::StackParameterScrubber.scrub!(stack.template)
+          stack.template = Sfn::Utils::StackParameterScrubber.scrub!(scrub_template(stack.template))
 
           if(config[:print_only])
             ui.puts _format_json(translate_template(stack.template))

--- a/lib/sfn/command/inspect.rb
+++ b/lib/sfn/command/inspect.rb
@@ -12,7 +12,7 @@ module Sfn
       def execute!
         name_required!
         stack_name = name_args.last
-        stack = provider.connection.stacks.get(stack_name)
+        stack = provider.stack(stack_name)
         ui.info "Stack inspection #{ui.color(stack_name, :bold)}:"
         outputs = api_action!(:api_stack => stack) do
           [:attribute, :nodes, :load_balancers, :instance_failure].map do |key|

--- a/lib/sfn/command/inspect.rb
+++ b/lib/sfn/command/inspect.rb
@@ -95,7 +95,7 @@ module Sfn
       def display_attribute(stack)
         [config[:attribute]].flatten.compact.each do |stack_attribute|
           attr = stack_attribute.split('.').inject(stack) do |memo, key|
-            args = key.scan(/\(([^)]*)\)/).flatten.first.to_s
+            args = key.scan(/\(([^\)]*)\)/).flatten.first.to_s
             if(args)
               args = args.split(',').map{|a| a.to_i.to_s == a ? a.to_i : a}
               key = key.split('(').first
@@ -129,7 +129,7 @@ module Sfn
             [
               asg.name,
               Smash[
-                asg.servers.map(&:expand).map{|s|
+                asg.servers.map(&:expand).compact.map{|s|
                   [s.id, Smash.new(
                       :name => s.name,
                       :addresses => s.addresses.map(&:address)
@@ -144,11 +144,13 @@ module Sfn
             resource.within?(:compute, :servers)
           end.map do |srv|
             srv = srv.instance
-            [srv.id, Smash.new(
+            if(srv)
+              [srv.id, Smash.new(
                 :name => srv.name,
                 :addresses => srv.addresses.map(&:address)
-            )]
-          end
+              )]
+            end
+          end.compact
         ]
         unless(asg_nodes.empty?)
           ui.info '  AutoScale Group Instances:'

--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -280,20 +280,6 @@ module Sfn
         end
       end
 
-      # Scrub sparkle/sfn customizations from the stack resource data
-      #
-      # @param template [Hash]
-      # @return [Hash]
-      def scrub_template(template)
-        template = Sfn::Utils::StackParameterScrubber.scrub!(template)
-        (template['Resources'] || {}).each do |r_name, r_content|
-          if(valid_stack_types.include?(r_content['Type']))
-            (r_content['Properties'] || {}).delete('Stack')
-          end
-        end
-        template
-      end
-
     end
   end
 end

--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -132,7 +132,7 @@ module Sfn
                 poll_stack(stack.name)
                 if(stack.reload.state == :update_complete)
                   ui.info "Stack update complete: #{ui.color('SUCCESS', :green)}"
-                  stack.resources.reload
+                  provider.stacks.reload
                   namespace.const_get(:Describe).new({:outputs => true}, [name]).execute!
                 else
                   ui.fatal "Update of stack #{ui.color(name, :bold)}: #{ui.color('FAILED', :red, :bold)}"
@@ -256,18 +256,22 @@ module Sfn
             unless(val[:diffs].empty?)
               p_name = nil
               val[:diffs].each do |diff|
-                if(diff[:updated] && diff[:original])
+                if(!diff[:updated].nil? || !diff[:original].nil?)
                   p_name = diff.fetch(:property_name, :path)
                   ui.print ' ' * 8
                   ui.print "#{p_name}: "
                   ui.print ' ' * (max_p - p_name.size)
-                  ui.print ui.color("-#{diff[:original]}", :red)
-                  ui.print ' ' * (max_o - diff[:original].size)
+                  ui.print ui.color("-#{diff[:original]}", :red) unless diff[:original].nil?
+                  ui.print ' ' * (max_o - diff[:original].to_s.size)
                   ui.print ' '
                   if(diff[:updated] == Sfn::Planner::RUNTIME_MODIFIED)
                     ui.puts ui.color("+#{diff[:original]} <Dependency Modified>", :green)
                   else
-                    ui.puts ui.color("+#{diff[:updated]}", :green)
+                    if(diff[:updated].nil?)
+                      ui.puts
+                    else
+                      ui.puts ui.color("+#{diff[:updated]}", :green)
+                    end
                   end
                 end
               end

--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -16,7 +16,7 @@ module Sfn
 
         stack_info = "#{ui.color('Name:', :bold)} #{name}"
         begin
-          stack = provider.connection.stacks.get(name)
+          stack = provider.stacks.get(name)
         rescue Miasma::Error::ApiError::RequestError
           stack = nil
         end
@@ -132,7 +132,6 @@ module Sfn
                 poll_stack(stack.name)
                 if(stack.reload.state == :update_complete)
                   ui.info "Stack update complete: #{ui.color('SUCCESS', :green)}"
-                  provider.stacks.reload
                   namespace.const_get(:Describe).new({:outputs => true}, [name]).execute!
                 else
                   ui.fatal "Update of stack #{ui.color(name, :bold)}: #{ui.color('FAILED', :red, :bold)}"

--- a/lib/sfn/command_module/base.rb
+++ b/lib/sfn/command_module/base.rb
@@ -81,7 +81,8 @@ module Sfn
         #
         # @param name [String] name of stack
         # @return [Miasma::Models::Orchestration::Stack]
-        def stack(name)
+        def stack(name=nil)
+          name = name_args.first unless name
           provider.stacks.get(name)
         end
 

--- a/lib/sfn/command_module/template.rb
+++ b/lib/sfn/command_module/template.rb
@@ -318,6 +318,20 @@ module Sfn
           stack_definition
         end
 
+        # Scrub sparkle/sfn customizations from the stack resource data
+        #
+        # @param template [Hash]
+        # @return [Hash]
+        def scrub_template(template)
+          template = Sfn::Utils::StackParameterScrubber.scrub!(template)
+          (template['Resources'] || {}).each do |r_name, r_content|
+            if(valid_stack_types.include?(r_content['Type']))
+              result = (r_content['Properties'] || {}).delete('Stack')
+            end
+          end
+          template
+        end
+
         # Update the nested stack information for specific provider
         #
         # @param provider [Symbol]

--- a/lib/sfn/command_module/template.rb
+++ b/lib/sfn/command_module/template.rb
@@ -214,16 +214,13 @@ module Sfn
         def process_nested_stack_shallow(sf, c_stack=nil)
           sf.apply_nesting(:shallow) do |stack_name, stack, resource|
             run_callbacks_for(:template, :stack_name => stack_name, :sparkle_stack => stack)
-            stack_definition = stack.compile.dump!
             bucket = provider.connection.api_for(:storage).buckets.get(
               config[:nesting_bucket]
             )
             if(config[:print_only])
               template_url = "http://example.com/bucket/#{name_args.first}_#{stack_name}.json"
             else
-              unless(config[:plan])
-                resource.properties.delete!(:stack)
-              end
+              stack_definition = dump_stack_for_storage(stack)
               unless(bucket)
                 raise "Failed to locate configured bucket for stack template storage (#{bucket})!"
               end
@@ -277,12 +274,7 @@ module Sfn
                   :current_parameters => current_parameters
                 )
               )
-              hold_stack = resource.properties.delete!(:stack)
-              stack_definition = stack.compile.dump!
-
-              if(config[:plan])
-                resource.properties.stack hold_stack
-              end
+              stack_definition = dump_stack_for_storage(stack)
               bucket = provider.connection.api_for(:storage).buckets.get(
                 config[:nesting_bucket]
               )
@@ -306,6 +298,24 @@ module Sfn
               resource.properties.set!(k, v)
             end
           end
+        end
+
+        # Remove internally used `Stack` property from Stack resources and
+        # and generate compiled Hash
+        #
+        # @param stack [SparkleFormation]
+        # @return [Hash]
+        def dump_stack_for_storage(stack)
+          nested_stacks = stack.nested_stacks.map do |nested_resource|
+            [nested_resource.resource_name!, stack.compile.resources.set!(nested_resource.resource_name!).properties.delete!(:stack)]
+          end
+          stack_definition = stack.compile.dump!
+          if(config[:plan])
+            nested_stacks.each do |nested_name, nested_data|
+              stack.compile.resources.set!(nested_name).properties.stack nested_data
+            end
+          end
+          stack_definition
         end
 
         # Update the nested stack information for specific provider

--- a/lib/sfn/config/events.rb
+++ b/lib/sfn/config/events.rb
@@ -23,6 +23,11 @@ module Sfn
         :description => 'Display all event attributes',
         :short_flag => 'A'
       )
+      attribute(
+        :all_events,  [TrueClass, FalseClass],
+        :description => 'Display all available events',
+        :short_flag => 'L'
+      )
 
     end
   end

--- a/lib/sfn/monkey_patch/stack.rb
+++ b/lib/sfn/monkey_patch/stack.rb
@@ -194,7 +194,7 @@ module Sfn
       # @param recurse [TrueClass, FalseClass] recurse to fetch _all_ stacks
       # @return [Array<Miasma::Models::Orchestration::Stack>]
       def nested_stacks(recurse=true)
-        resources.all.map do |resource|
+        resources.reload.all.map do |resource|
           if(api.data.fetch(:stack_types, []).include?(resource.type))
             # Custom remote load support
             if(resource.type == 'Custom::JackalStack')

--- a/lib/sfn/planner/aws.rb
+++ b/lib/sfn/planner/aws.rb
@@ -354,7 +354,11 @@ module Sfn
           else
             if(p_path.include?('Properties'))
               resource_name = p_path[1]
-              property_name = p_path[3].sub(/\[\d+\]$/, '')
+              if(p_path.size < 4 && p_path.last == 'Properties')
+                property_name = diff.flatten.compact.last.keys.first
+              else
+                property_name = p_path[3].to_s.sub(/\[\d+\]$/, '')
+              end
               type = templates[:origin]['Resources'][resource_name]['Type']
               info = SfnAws.registry.fetch(type, {})
               effect = info[:full_properties].fetch(property_name, {}).fetch(:update_causes, :unknown).to_sym

--- a/lib/sfn/provider.rb
+++ b/lib/sfn/provider.rb
@@ -94,7 +94,13 @@ module Sfn
 
     # @return [String] json representation of cached stacks
     def cached_stacks(stack_id=nil)
-      fetch_stacks(stack_id) unless @initial_fetch_complete
+      unless(@initial_fetch_complete || stack_id)
+        recache = true
+        if(stack_id && @initial_fetch_complete)
+          recache = !!stacks.get(stack_id)
+        end
+        fetch_stacks(stack_id) if recache
+      end
       value = cache[:stacks].value
       value ? MultiJson.dump(MultiJson.load(value).values) : '[]'
     end

--- a/sfn.gemspec
+++ b/sfn.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.license = 'Apache-2.0'
   s.require_path = 'lib'
   s.add_runtime_dependency 'bogo-cli', '>= 0.2.4', '< 0.4'
+  s.add_runtime_dependency 'bogo-ui', '>= 0.1.13', '< 0.4'
   s.add_runtime_dependency 'miasma', '>= 0.3.0', '< 0.4'
   s.add_runtime_dependency 'miasma-aws', '>= 0.3.0', '< 0.4'
   s.add_runtime_dependency 'miasma-azure', '>= 0.1.0', '< 0.3'


### PR DESCRIPTION
Properly ensures stack artifacts are removed from deeply nested stacks
containing multiple stack resources.