### PR TITLE
Set config defined options into stack instance on update

### DIFF
--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -125,6 +125,13 @@ module Sfn
             stack.parameters = config_root_parameters
           end
 
+          # Set options defined within config into stack instance for update request
+          config.fetch(:options, Smash.new).each_pair do |key, value|
+            if(stack.respond_to?("#{key}="))
+              stack.send("#{key}=", value)
+            end
+          end
+
           begin
             api_action!(:api_stack => stack) do
               stack.save


### PR DESCRIPTION
On stack update set all values defined within config options into
stack instance prior to save. Provider driver can handle any needed
logic to disable invalid options. Provides #154