### PR TITLE
Make API option merging on update behavior "opt-in"

### DIFF
--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -120,9 +120,11 @@ module Sfn
           end
 
           # Set options defined within config into stack instance for update request
-          config.fetch(:options, Smash.new).each_pair do |key, value|
-            if(stack.respond_to?("#{key}="))
-              stack.send("#{key}=", value)
+          if(config[:merge_api_options])
+            config.fetch(:options, Smash.new).each_pair do |key, value|
+              if(stack.respond_to?("#{key}="))
+                stack.send("#{key}=", value)
+              end
             end
           end
 

--- a/lib/sfn/config/update.rb
+++ b/lib/sfn/config/update.rb
@@ -50,6 +50,11 @@ module Sfn
         :description => 'Show planner content diff',
         :short_flag => 'D'
       )
+      attribute(
+        :merge_api_options, [TrueClass, FalseClass],
+        :description => 'Merge API options defined within configuration on update',
+        :default => false
+      )
 
     end
   end


### PR DESCRIPTION
This is an update to #157 which addresses #154. The update provided in #157
ended up breaking my stack updates. The cause was due to propagation of tags
to supported resources and my stack containing "missing resources". Because
this would be considered a breaking change I'm going to restrict this behavior
to being opt-in and will look to default the behavior on the next major release.