### PR TITLE
Autoload sparklepacks from bundler

### DIFF
--- a/lib/sfn/command_module/template.rb
+++ b/lib/sfn/command_module/template.rb
@@ -80,7 +80,14 @@ module Sfn
         # @return [Array<SparkleFormation::SparklePack>]
         def sparkle_packs
           memoize(:sparkle_packs) do
-            [config.fetch(:sparkle_pack, [])].flatten.compact.map do |sparkle_name|
+            if(defined?(Bundler))
+              packs = Bundler.load.current_dependencies.map(&:name).select do |gem|
+                gem.include?("sparkle-pack")
+              end
+            else
+              packs = []
+            end
+            [config.fetch(:sparkle_pack, [])].flatten.concat(packs).compact.map do |sparkle_name|
               begin
                 require sparkle_name
               rescue LoadError


### PR DESCRIPTION
This covers the most common SparklePack implicit-loading case, I believe:

If bundler is present, add all gems that include "sparkle-pack" in the name into the `sparkle_pack` array, otherwise do nothing. Packs may also be defined via `.sfn`.

This is really useful when a pack depends on other packs.