### PR TITLE
Restrict automatic requires to sfn group if present

### DIFF
--- a/bin/sfn
+++ b/bin/sfn
@@ -5,7 +5,11 @@ require 'sfn'
 
 if(defined?(Bundler))
   begin
-    Bundler.require
+    if(Bundler.definition.groups.include?(:sfn))
+      Bundler.require(:sfn)
+    else
+      Bundler.require
+    end
   rescue Bundler::GemfileNotFound
     # ignore load error
   end


### PR DESCRIPTION
Based off #172 but checks defined groups within definition instead
of dependency names. Retains existing default require behavior if
group not defined.