### PR TITLE
Planner refactor and SparkleFormation resources integration

### DIFF
--- a/lib/sfn/planner/aws.rb
+++ b/lib/sfn/planner/aws.rb
@@ -108,7 +108,8 @@ module Sfn
 
       # Resources that will be replaced on metadata init updates
       REPLACE_ON_CFN_INIT_UPDATE = [
-        'AWS::AutoScaling::LaunchConfiguration'
+        'AWS::AutoScaling::LaunchConfiguration',
+        'AWS::EC2::Instance'
       ]
 
       # @return [Smash] initialized translators
@@ -145,7 +146,6 @@ module Sfn
           :unavailable => Smash.new,
           :unknown => Smash.new
         )
-#        scrub_stack_properties(template)
         result
       end
 
@@ -203,17 +203,21 @@ module Sfn
         origin_template = dereference_template(
           "#{stack.data.checksum}_origin",
           stack.template,
-          Smash[stack.parameters.map{|k,v| [k, v.to_s]}].merge(get_global_parameters(stack))
+          Smash[
+            stack.parameters.map do |k,v|
+              [k, v.to_s]
+            end
+          ].merge(get_global_parameters(stack))
         )
 
-        t_key = "#{stack.data.checksum}_#{stack.data.fetch(:logical_id, stack.name)}"
-        run_stack_diff(stack, t_key, plan_results, origin_template, new_template, new_parameters)
+        translator_key = "#{stack.data.checksum}_#{stack.data.fetch(:logical_id, stack.name)}"
+        run_stack_diff(stack, translator_key, plan_results, origin_template, new_template, new_parameters)
 
         new_checksum = nil
         current_checksum = false
         until(new_checksum == current_checksum)
           current_checksum = plan_results.checksum
-          run_stack_diff(stack, t_key, plan_results, origin_template, new_template, new_parameters)
+          run_stack_diff(stack, translator_key, plan_results, origin_template, new_template, new_parameters)
           new_checksum = plan_results.checksum
         end
         scrub_plan(plan_results)
@@ -249,6 +253,7 @@ module Sfn
       # Run the stack diff and populate the result set
       #
       # @param stack [Miasma::Models::Orchestration::Stack] existing stack
+      # @param t_key [String] translator key
       # @param plan_result [Smash] plan data to populate
       # @param origin_template [Smash] template of existing stack
       # @param new_template [Smash] template to replace existing
@@ -256,7 +261,6 @@ module Sfn
       # @return [NilClass]
       def run_stack_diff(stack, t_key, plan_results, origin_template, new_template, new_parameters)
         translator = translator_for(t_key)
-
         new_parameters = new_parameters.dup
         if(stack.parameters)
           stack.parameters.each do |k,v|
@@ -266,49 +270,11 @@ module Sfn
             end
           end
         end
-
         new_parameters.merge!(get_global_parameters(stack))
-
         new_template_hash = new_template.to_smash
-
-        o_nested_stacks = origin_template.fetch('Resources', {}).find_all do |s_name, s_val|
-          is_stack?(s_val['Type'])
-        end.map(&:first)
-        n_nested_stacks = (new_template_hash['Resources'] || {}).find_all do |s_name, s_val|
-          is_stack?(s_val['Type'])
-        end.map(&:first)
-        [o_nested_stacks + n_nested_stacks].flatten.compact.uniq.each do |n_name|
-          o_stack = stack.nested_stacks(false).detect{|s| s.data[:logical_id] == n_name}
-          n_exists = is_stack?(new_template_hash.get('Resources', n_name, 'Type'))
-          n_template = new_template_hash.get('Resources', n_name, 'Properties', 'Stack')
-          n_parameters = new_template_hash.fetch('Resources', n_name, 'Properties', 'Parameters', Smash.new)
-          n_type = new_template_hash.fetch('Resources', n_name, 'Type',
-            origin_template.get('Resources', n_name, 'Type')
-          )
-          resource = Smash.new(
-            :name => n_name,
-            :type => n_type,
-            :properties => []
-          )
-          if(o_stack && n_template)
-            n_parameters.keys.each do |n_key|
-              n_parameters[n_key] = translator.dereference(n_parameters[n_key])
-            end
-            n_results = plan_stack(o_stack, n_template, n_parameters)
-            unless(n_results[:outputs].empty?)
-              n_results[:outputs].keys.each do |n_output|
-                translator.flag_ref("#{n_name}_Outputs.#{n_output}")
-              end
-            end
-            plan_results[:stacks][n_name] = n_results
-          elsif(o_stack && (!n_template && !n_exists))
-            plan_results[:removed][n_name] = resource
-          elsif(n_template && !o_stack)
-            plan_results[:added][n_name] = resource
-          end
-        end
-
         scrub_stack_properties(new_template_hash)
+
+        plan_nested_stacks(stack, translator, origin_template, new_template_hash, plan_results)
 
         update_template = dereference_template(
           t_key, new_template_hash, new_parameters,
@@ -320,23 +286,72 @@ module Sfn
         end.each do |a_path, diff_items|
           register_diff(
             plan_results, a_path, diff_items, translator_for(t_key),
-            :origin => origin_template,
-            :update => update_template
+            Smash.new(
+              :origin => origin_template,
+              :update => update_template
+            )
           )
         end
         nil
       end
 
-      # Register a diff item into the results set
+      # Extract nested stacks and generate plans
       #
-      # @param results [Hash]
-      # @param path [String]
-      # @param diff [Array]
-      # @param templates [Hash]
-      # @option :templates [Hash] :origin
-      # @option :templates [Hash] :update
-      def register_diff(results, path, diff, translator, templates)
-        diff_info = Smash.new.tap do |di|
+      # @param stack [Miasma::Orchestration::Models::Stack]
+      # @param translator [Translator]
+      # @param origin_template [Smash]
+      # @param new_template_hash [Smash]
+      # @param plan_results [Smash]
+      # @return [NilClass]
+      def plan_nested_stacks(stack, translator, origin_template, new_template_hash, plan_results)
+        origin_stacks = origin_template.fetch('Resources', {}).find_all do |s_name, s_val|
+          is_stack?(s_val['Type'])
+        end.map(&:first)
+        new_stacks = (new_template_hash['Resources'] || {}).find_all do |s_name, s_val|
+          is_stack?(s_val['Type'])
+        end.map(&:first)
+        [origin_stacks + new_stacks].flatten.compact.uniq.each do |stack_name|
+          original_stack = stack.nested_stacks(false).detect do |stk|
+            stk.data[:logical_id] == stack_name
+          end
+          new_stack_exists = is_stack?(new_template_hash.get('Resources', stack_name, 'Type'))
+          new_stack_template = new_template_hash.get('Resources', stack_name, 'Properties', 'Stack')
+          new_stack_parameters = new_stack_template.fetch('Parameters', Smash.new)
+          new_stack_type = new_template_hash.fetch('Resources', stack_name, 'Type',
+            origin_template.get('Resources', stack_name, 'Type')
+          )
+          resource = Smash.new(
+            :name => stack_name,
+            :type => new_stack_type,
+            :properties => []
+          )
+          if(original_stack && new_stack_template)
+            new_stack_parameters = Smash[
+              new_stack_parameters.map do |new_param_key, new_param_value|
+                [new_param_key, translator.dereference(new_param_value)]
+              end
+            ]
+            result = plan_stack(original_stack, new_stack_template, new_stack_parameters)
+            result[:outputs].keys.each do |modified_output|
+              translator.flag_ref("#{stack_name}_Outputs.#{modified_output}")
+            end
+            plan_results[:stacks][stack_name] = result
+          elsif(original_stack && (!new_stack_template && !new_stack_exists))
+            plan_results[:removed][stack_name] = resource
+          elsif(new_stack_template && !original_stack)
+            plan_results[:added][stack_name] = resource
+          end
+        end
+        nil
+      end
+
+      # Initialize the diff result hash
+      #
+      # @param diff [Array] Hashdiff result entry
+      # @param path [String] modification path within structure
+      # @return [Smash]
+      def diff_init(diff, path)
+        Smash.new.tap do |di|
           if(diff.size > 1)
             updated = diff.detect{|x| x.first == '+'}
             original = diff.detect{|x| x.first == '-'}
@@ -353,12 +368,24 @@ module Sfn
             end
           end
         end
+      end
+
+      # Register a diff item into the results set
+      #
+      # @param results [Hash]
+      # @param path [String]
+      # @param diff [Array]
+      # @param templates [Smash]
+      # @option :templates [Smash] :origin
+      # @option :templates [Smash] :update
+      def register_diff(results, path, diff, translator, templates)
+        diff_info = diff_init(diff, path)
         if(path.start_with?('Resources'))
           p_path = path.split('.')
           if(p_path.size == 2)
             diff = diff.first
             key = diff.first == '+' ? :added : :removed
-            type = (key == :added ? templates[:update] : templates[:origin])['Resources'][p_path.last]['Type']
+            type = (key == :added ? templates[:update] : templates[:origin]).get('Resources', p_path.last, 'Type')
             results[key][p_path.last] = Smash.new(
               :name => p_path.last,
               :type => type,
@@ -375,9 +402,7 @@ module Sfn
               else
                 property_name = p_path[3].to_s.sub(/\[\d+\]$/, '')
               end
-              type = templates[:origin]['Resources'][resource_name]['Type']
-              info = SfnAws.registry.fetch(type, {}).to_smash
-              effect = info.fetch(:full_properties, property_name, :update_causes, :unknown).to_sym
+              type = templates.get(:origin, 'Resources', resource_name, 'Type')
               resource = Smash.new(
                 :name => resource_name,
                 :type => type,
@@ -386,16 +411,30 @@ module Sfn
                   diff_info.merge(:property_name => property_name)
                 ]
               )
-              case effect
-              when :replacement
-                set_resource(:replace, results, resource_name, resource)
-              when :interrupt
-                set_resource(:interrupt, results, resource_name, resource)
-              when :unavailable
-                set_resource(:unavailable, results, resource_name, resource)
-              when :none
-                # \o/
-              else
+              begin
+                r_info = SparkleFormation::Resources::Aws.resource_lookup(type)
+                r_property = r_info.property(property_name)
+                if(r_property)
+                  effect = r_property.update_causes(
+                    templates.get(:update, 'Resources', resource_name),
+                    templates.get(:origin, 'Resources', resource_name)
+                  )
+                else
+                  raise KeyError.new 'Unknown property'
+                end
+                case effect.to_sym
+                when :replacement
+                  set_resource(:replace, results, resource_name, resource)
+                when :interrupt
+                  set_resource(:interrupt, results, resource_name, resource)
+                when :unavailable
+                  set_resource(:unavailable, results, resource_name, resource)
+                when :none
+                  # \o/
+                else
+                  set_resource(:unknown, results, resource_name, resource)
+                end
+              rescue KeyError
                 set_resource(:unknown, results, resource_name, resource)
               end
             elsif(p_path.include?('AWS::CloudFormation::Init'))


### PR DESCRIPTION
This changeset provides a starting point for refactoring the AWS planner
implementation for the initial POC to be a bit more verbose and to better
confine logic. It also adds integration of SparkleFormation::Resources which
includes support for conditional effect logic on resource property updates.

Initial planner refactor and integration of SparkleFormation resources