### PR TITLE
Include underscore suffix on compile time parameter matching

### DIFF
--- a/lib/sfn/config/validate.rb
+++ b/lib/sfn/config/validate.rb
@@ -83,7 +83,7 @@ module Sfn
             v.split(',').each do |item_pair|
               key, value = item_pair.split(/[=:]/, 2)
               key = key.split('__')
-              key = [key.pop, key.map{|x| Bogo::Utility.camel(x)}.join('__')].reverse
+              key = [key.pop, key.join('__')].reverse
               result.set(*key, value)
             end
             result

--- a/test/specs/command_module/template_spec.rb
+++ b/test/specs/command_module/template_spec.rb
@@ -1,0 +1,41 @@
+require_relative '../../helper'
+
+describe Sfn::CommandModule::Template do
+
+  before do
+    @template = Class.new do
+      def initialize
+        @config = Smash.new
+        @arguments = []
+        @ui = AttributeStruct.new
+      end
+      attr_reader :config, :arguments, :ui
+    end
+    @template.include Sfn::CommandModule::Template
+  end
+
+  let(:instance){ @instance ||= @template.new }
+
+  describe 'Compile time parameter merging' do
+
+    it 'should automatically merge items when stack name is not used' do
+      instance.arguments << 'stack-name'
+      instance.config.set(:compile_parameters, 'stack-name__Fubar', 'key1', 'value')
+      instance.config.set(:compile_parameters, 'Fubar', 'key2', 'value2')
+      result = instance.merge_compile_time_parameters
+      result.get('stack-name__Fubar', 'key1').must_equal 'value'
+      result.get('stack-name__Fubar', 'key2').must_equal 'value2'
+      result.get('Fubar').must_be_nil
+    end
+
+    it 'should automatically prefix stack name when not provided' do
+      instance.arguments << 'stack-name'
+      instance.config.set(:compile_parameters, 'Fubar', 'key2', 'value2')
+      result = instance.merge_compile_time_parameters
+      result.get('stack-name__Fubar', 'key2').must_equal 'value2'
+      result.get('Fubar').must_be_nil
+    end
+
+  end
+
+end

--- a/test/specs/config/json-ext/.sfn.json
+++ b/test/specs/config/json-ext/.sfn.json
@@ -1,0 +1,3 @@
+{
+  "processing": false
+}

--- a/test/specs/config/ruby-ext/.sfn.rb
+++ b/test/specs/config/ruby-ext/.sfn.rb
@@ -1,0 +1,3 @@
+Configuration.new do
+  processing false
+end


### PR DESCRIPTION
When removing and merging config provided compile time values always
include underscore suffix when identifying match to prevent removal of
core parameter set.