### PR TITLE
Quieter --print-only output - Issue #202

### DIFF
--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -58,7 +58,9 @@ module Sfn
           raise "Failed to locate stack: #{name}"
         end
 
-        ui.info "#{ui.color('SparkleFormation:', :bold)} #{ui.color('update', :green)}"
+        unless(config[:print_only])
+          ui.info "#{ui.color('SparkleFormation:', :bold)} #{ui.color('update', :green)}"
+        end
 
         unless(file)
           if(config[:template])
@@ -68,7 +70,9 @@ module Sfn
             stack_info << " #{ui.color('(no template update)', :yellow)}"
           end
         end
-        ui.info "  -> #{stack_info}"
+        unless(config[:print_only])
+          ui.info "  -> #{stack_info}"
+        end
         if(file)
           if(config[:print_only])
             ui.puts format_json(parameter_scrub!(template_content(file)))

--- a/lib/sfn/command_module/callbacks.rb
+++ b/lib/sfn/command_module/callbacks.rb
@@ -32,6 +32,7 @@ module Sfn
           callbacks_for(c_type)
         end.flatten(1).compact.uniq.each do |item|
           callback_name, callback, quiet = item
+          quiet = true if config[:print_only]
           ui.info "Callback #{ui.color(type.to_s, :bold)} #{callback_name}: #{ui.color('starting', :yellow)}" unless quiet
           if(args.empty?)
             callback.call


### PR DESCRIPTION
Tries to address issue https://github.com/sparkleformation/sfn/issues/202

 - Makes callback output quiet when --print-only used.
 - Makes update --print-only as quiet as create --print-only

