### PR TITLE
Fix save stack policy

### DIFF
--- a/lib/sfn/callback/stack_policy.rb
+++ b/lib/sfn/callback/stack_policy.rb
@@ -80,8 +80,8 @@ module Sfn
           @policies[p_stack.name]
         ).to_smash
         if(stack_policy)
-          stack_policy[:statement].delete_if do |policy_item|
-            policy_match = policy_item[:resource].to_s.match(
+          stack_policy[:Statement].delete_if do |policy_item|
+            policy_match = policy_item[:Resource].to_s.match(
               %r{LogicalResourceId/(?<logical_id>.+)$}
             )
             if(policy_match)


### PR DESCRIPTION
Hi,

After updating to sfn 3.0.26 I'm getting a weird error when updating my stacks:
```
...
[Sfn]: Applying stack policy to MyStack... error!
[ERROR]: Reason - undefined method `delete_if' for nil:NilClass
ERROR: NoMethodError: undefined method `delete_if' for nil:NilClass
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/callback/stack_policy.rb:83:in `save_stack_policy'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/callback/stack_policy.rb:36:in `block (2 levels) in submit_policy'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/callback.rb:43:in `run_action'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/callback/stack_policy.rb:35:in `block in submit_policy'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/callback/stack_policy.rb:34:in `each'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/callback/stack_policy.rb:34:in `submit_policy'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/command_module/callbacks.rb:40:in `call'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/command_module/callbacks.rb:40:in `block in run_callbacks_for'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/command_module/callbacks.rb:33:in `each'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/command_module/callbacks.rb:33:in `run_callbacks_for'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/command_module/callbacks.rb:20:in `api_action!'
/Users/pedrocarrico/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sfn-3.0.26/lib/sfn/command/update.rb:143:in `execute!'
<snip>
```

After opening up `stack_policy.rb` and a little bit of investigation with pry I found the cause was that  the key on `stack_policy` wasn't quite right:

```ruby
[1] pry(#<Sfn::Callback::StackPolicy>)> stack_policy[:statement]
=> nil
[2] pry(#<Sfn::Callback::StackPolicy>)> stack_policy[:Statement]
=> [{"Effect"=>"Allow", "Action"=>"Update:*", "Resource"=>"*", "Principal"=>"*"}]
[3] pry(#<Sfn::Callback::StackPolicy>)> @policies
=> {"MyStack"=>
  {"Statement"=>[{"Effect"=>"Allow", "Action"=>"Update:*", "Resource"=>"*", "Principal"=>"*"}]}}
[4] pry(#<Sfn::Callback::StackPolicy>)> stack_policy.class
=> Bogo::Smash
```
Not sure if this is a proper fix, but this seems to work on my stacks.

Thanks,