### PR TITLE
Fix comma-delimited parameter type parsing coming from the CLI

### DIFF
--- a/lib/sfn/config.rb
+++ b/lib/sfn/config.rb
@@ -20,7 +20,7 @@ module Sfn
             case v
             when String
               Smash[
-                v.split(',').map do |item_pair|
+                v.split(/,(?=[^,]*:)/).map do |item_pair|
                   item_pair.split(/[=:]/, 2)
                 end
               ]


### PR DESCRIPTION
Hi,

I noticed that my comma delimited parameters where being incorrectly parsed when I was passing them in the CLI.

```
bundle exec sfn create --parameters CDLKey:Value1,Value2,Value3,AnotherKey2:AnotherValue1
```

In that example my `CDLKey` would only get assigned the value of `Value1` and not the full comma-delimited value of `Value1,Value2,Value3`.

With this proposed fix (using a positive lookahead) the values passed to `Smash` are correctly mapped and sent to the provider.

Thanks,