### PR TITLE
Allow validate on files outside sparkleformation path, fixes #278

### DIFF
--- a/lib/chef/knife/knife_plugin_seed.rb
+++ b/lib/chef/knife/knife_plugin_seed.rb
@@ -1,14 +1,14 @@
 begin
-  kcfn = Gem::Specification.find_by_name('knife-cloudformation')
+  kcfn = Gem::Specification.find_by_name("knife-cloudformation")
   $stderr.puts "[WARN]: Deprecated gem detected: #{kcfn.name} [V: #{kcfn.version}]"
-  $stderr.puts '[WARN]: Uninstall gem to prevent any conflicts (`gem uninstall knife-cloudformation -a`)'
+  $stderr.puts "[WARN]: Uninstall gem to prevent any conflicts (`gem uninstall knife-cloudformation -a`)"
 rescue Gem::LoadError => e
   # ignore
 end
 
 unless defined?(Chef::Knife::CloudformationCreate)
-  require 'sfn'
-  require 'bogo'
+  require "sfn"
+  require "bogo"
 
   Chef::Config[:knife][:cloudformation] = {
     :options => {},
@@ -17,7 +17,7 @@ unless defined?(Chef::Knife::CloudformationCreate)
   }
   Chef::Config[:knife][:sparkleformation] = Chef::Config[:knife][:cloudformation]
 
-  VALID_PREFIX = ['cloudformation', 'sparkleformation']
+  VALID_PREFIX = ["cloudformation", "sparkleformation"]
 
   Sfn::Config.constants.map do |konst|
     const = Sfn::Config.const_get(konst)
@@ -26,7 +26,7 @@ unless defined?(Chef::Knife::CloudformationCreate)
     end
   end.compact.sort_by(&:to_s).each do |klass|
     VALID_PREFIX.each do |prefix|
-      klass_name = klass.name.split('::').last
+      klass_name = klass.name.split("::").last
       command_class = "#{prefix.capitalize}#{klass_name}"
 
       knife_klass = Class.new(Chef::Knife)
@@ -54,7 +54,7 @@ unless defined?(Chef::Knife::CloudformationCreate)
           end
           base = knife.to_smash
           keys = VALID_PREFIX.dup
-          cmd_config = keys.unshift(keys.delete(snake(self.class.name.split('::').last).to_s.split('_').first)).map do |k|
+          cmd_config = keys.unshift(keys.delete(snake(self.class.name.split("::").last).to_s.split("_").first)).map do |k|
             base[k]
           end.compact.first || {}
           cmd_config = cmd_config.to_smash
@@ -64,8 +64,8 @@ unless defined?(Chef::Knife::CloudformationCreate)
           end
           # Split up options provided multiple arguments
           reconfig.map! do |k, v|
-            if v.is_a?(String) && v.include?(',')
-              v = v.split(',').map(&:strip)
+            if v.is_a?(String) && v.include?(",")
+              v = v.split(",").map(&:strip)
             end
             [k, v]
           end
@@ -82,7 +82,7 @@ unless defined?(Chef::Knife::CloudformationCreate)
       knife_klass.instance_variable_set(:@name, "Chef::Knife::#{command_class}")
       knife_klass.instance_variable_set(
         :@sfn_class,
-        Bogo::Utility.constantize(klass.name.sub('Config', 'Command'))
+        Bogo::Utility.constantize(klass.name.sub("Config", "Command"))
       )
       knife_klass.banner "knife #{prefix} #{Bogo::Utility.snake(klass_name)}"
 
@@ -91,9 +91,9 @@ unless defined?(Chef::Knife::CloudformationCreate)
           short = "-#{info[:short]}"
           long = "--[no-]#{info[:long]}"
         else
-          val = 'VALUE'
+          val = "VALUE"
           if info[:multiple]
-            val << '[,VALUE]'
+            val << "[,VALUE]"
           end
           short = "-#{info[:short]} #{val}"
           long = "--#{info[:long]} #{val}"

--- a/lib/sfn.rb
+++ b/lib/sfn.rb
@@ -1,20 +1,20 @@
-require 'sfn/version'
-require 'miasma'
-require 'bogo'
-require 'sparkle_formation'
+require "sfn/version"
+require "miasma"
+require "bogo"
+require "sparkle_formation"
 
 module Sfn
-  autoload :ApiProvider, 'sfn/api_provider'
-  autoload :Callback, 'sfn/callback'
-  autoload :Provider, 'sfn/provider'
-  autoload :Cache, 'sfn/cache'
-  autoload :Config, 'sfn/config'
-  autoload :Export, 'sfn/export'
-  autoload :Utils, 'sfn/utils'
-  autoload :MonkeyPatch, 'sfn/monkey_patch'
-  autoload :Knife, 'sfn/knife'
-  autoload :Command, 'sfn/command'
-  autoload :CommandModule, 'sfn/command_module'
-  autoload :Planner, 'sfn/planner'
-  autoload :Lint, 'sfn/lint'
+  autoload :ApiProvider, "sfn/api_provider"
+  autoload :Callback, "sfn/callback"
+  autoload :Provider, "sfn/provider"
+  autoload :Cache, "sfn/cache"
+  autoload :Config, "sfn/config"
+  autoload :Export, "sfn/export"
+  autoload :Utils, "sfn/utils"
+  autoload :MonkeyPatch, "sfn/monkey_patch"
+  autoload :Knife, "sfn/knife"
+  autoload :Command, "sfn/command"
+  autoload :CommandModule, "sfn/command_module"
+  autoload :Planner, "sfn/planner"
+  autoload :Lint, "sfn/lint"
 end

--- a/lib/sfn/api_provider.rb
+++ b/lib/sfn/api_provider.rb
@@ -1,8 +1,8 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module ApiProvider
-    autoload :Google, 'sfn/api_provider/google'
-    autoload :Terraform, 'sfn/api_provider/terraform'
+    autoload :Google, "sfn/api_provider/google"
+    autoload :Terraform, "sfn/api_provider/terraform"
   end
 end

--- a/lib/sfn/api_provider/google.rb
+++ b/lib/sfn/api_provider/google.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module ApiProvider
@@ -43,7 +43,7 @@ module Sfn
       # @return [TrueClass, FalseClass]
       def function_set_parameter?(val)
         if val
-          val.start_with?('$(') || val.start_with?('{{')
+          val.start_with?("$(") || val.start_with?("{{")
         end
       end
 

--- a/lib/sfn/api_provider/terraform.rb
+++ b/lib/sfn/api_provider/terraform.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module ApiProvider
@@ -43,7 +43,7 @@ module Sfn
       # @return [TrueClass, FalseClass]
       def function_set_parameter?(val)
         if val
-          val.start_with?('${')
+          val.start_with?("${")
         end
       end
 

--- a/lib/sfn/cache.rb
+++ b/lib/sfn/cache.rb
@@ -1,6 +1,6 @@
-require 'digest/sha2'
-require 'thread'
-require 'sfn'
+require "digest/sha2"
+require "thread"
+require "sfn"
 
 module Sfn
   # Data caching helper
@@ -16,9 +16,9 @@ module Sfn
         case type
         when :redis
           begin
-            require 'redis-objects'
+            require "redis-objects"
           rescue LoadError
-            $stderr.puts 'The `redis-objects` gem is required for Cache support!'
+            $stderr.puts "The `redis-objects` gem is required for Cache support!"
             raise
           end
           @_pid = Process.pid
@@ -168,7 +168,7 @@ module Sfn
       when :lock
         Redis::Lock.new(full_name, {:expiration => 60, :timeout => 0.1}.merge(args))
       when :stamped
-        Stamped.new(full_name.sub("#{key}_", '').to_sym, get_redis_storage(:value, full_name), self)
+        Stamped.new(full_name.sub("#{key}_", "").to_sym, get_redis_storage(:value, full_name), self)
       else
         raise TypeError.new("Unsupported caching data type encountered: #{data_type}")
       end
@@ -193,7 +193,7 @@ module Sfn
                               when :lock
                                 LocalLock.new(full_name, {:expiration => 60, :timeout => 0.1}.merge(args))
                               when :stamped
-                                Stamped.new(full_name.sub("#{key}_", '').to_sym, get_local_storage(:value, full_name), self)
+                                Stamped.new(full_name.sub("#{key}_", "").to_sym, get_local_storage(:value, full_name), self)
                               else
                                 raise TypeError.new("Unsupported caching data type encountered: #{data_type}")
                               end
@@ -227,7 +227,7 @@ module Sfn
     # @param val [Object]
     # @note this will never work, thus you should never use it
     def []=(key, val)
-      raise 'Setting backend data is not allowed'
+      raise "Setting backend data is not allowed"
     end
 
     # Check if cache time has expired
@@ -263,7 +263,7 @@ module Sfn
           yield
         end
       rescue => e
-        if e.class.to_s.end_with?('Timeout')
+        if e.class.to_s.end_with?("Timeout")
           raise if raise_on_locked
         else
           raise

--- a/lib/sfn/callback.rb
+++ b/lib/sfn/callback.rb
@@ -1,11 +1,11 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   # Interface for injecting custom functionality
   class Callback
-    autoload :AwsAssumeRole, 'sfn/callback/aws_assume_role'
-    autoload :AwsMfa, 'sfn/callback/aws_mfa'
-    autoload :StackPolicy, 'sfn/callback/stack_policy'
+    autoload :AwsAssumeRole, "sfn/callback/aws_assume_role"
+    autoload :AwsMfa, "sfn/callback/aws_mfa"
+    autoload :StackPolicy, "sfn/callback/stack_policy"
 
     # @return [Bogo::Ui]
     attr_reader :ui
@@ -40,10 +40,10 @@ module Sfn
       ui.info("#{msg}... ", :nonewline)
       begin
         result = yield
-        ui.puts ui.color('complete!', :green, :bold)
+        ui.puts ui.color("complete!", :green, :bold)
         result
       rescue => e
-        ui.puts ui.color('error!', :red, :bold)
+        ui.puts ui.color("error!", :red, :bold)
         ui.error "Reason - #{e}"
         raise
       end

--- a/lib/sfn/callback/aws_assume_role.rb
+++ b/lib/sfn/callback/aws_assume_role.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Callback
@@ -31,14 +31,14 @@ module Sfn
       def after(*_)
         if enabled?
           if api.connection.aws_sts_role_arn && api.connection.aws_sts_token
-            path = config.fetch(:aws_assume_role, :cache_file, '.sfn-aws')
+            path = config.fetch(:aws_assume_role, :cache_file, ".sfn-aws")
             FileUtils.touch(path)
             File.chmod(0600, path)
             values = load_stored_values(path)
             STS_STORE_ITEMS.map do |key|
               values[key] = api.connection.data[key]
             end
-            File.open(path, 'w') do |file|
+            File.open(path, "w") do |file|
               file.puts MultiJson.dump(values)
             end
           end
@@ -47,14 +47,14 @@ module Sfn
 
       # @return [TrueClass, FalseClass]
       def enabled?
-        config.fetch(:aws_assume_role, :status, 'enabled').to_s == 'enabled'
+        config.fetch(:aws_assume_role, :status, "enabled").to_s == "enabled"
       end
 
       # Load stored configuration data into the api connection
       #
       # @return [TrueClass, FalseClass]
       def load_stored_session
-        path = config.fetch(:aws_assume_role, :cache_file, '.sfn-aws')
+        path = config.fetch(:aws_assume_role, :cache_file, ".sfn-aws")
         if File.exists?(path)
           values = load_stored_values(path)
           STS_STORE_ITEMS.each do |key|

--- a/lib/sfn/callback/aws_mfa.rb
+++ b/lib/sfn/callback/aws_mfa.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Callback
@@ -32,31 +32,32 @@ module Sfn
       def after(*_)
         if enabled?
           if api.connection.aws_sts_session_token
-            path = config.fetch(:aws_mfa, :cache_file, '.sfn-aws')
+            path = config.fetch(:aws_mfa, :cache_file, ".sfn-aws")
             FileUtils.touch(path)
             File.chmod(0600, path)
             values = load_stored_values(path)
             SESSION_STORE_ITEMS.map do |key|
               values[key] = api.connection.data[key]
             end
-            File.open(path, 'w') do |file|
+            File.open(path, "w") do |file|
               file.puts MultiJson.dump(values)
             end
           end
         end
       end
+
       alias_method :failed, :after
 
       # @return [TrueClass, FalseClass]
       def enabled?
-        config.fetch(:aws_mfa, :status, 'enabled').to_s == 'enabled'
+        config.fetch(:aws_mfa, :status, "enabled").to_s == "enabled"
       end
 
       # Load stored configuration data into the api connection
       #
       # @return [TrueClass, FalseClass]
       def load_stored_session
-        path = config.fetch(:aws_mfa, :cache_file, '.sfn-aws')
+        path = config.fetch(:aws_mfa, :cache_file, ".sfn-aws")
         if File.exists?(path)
           values = load_stored_values(path)
           SESSION_STORE_ITEMS.each do |key|
@@ -94,7 +95,7 @@ module Sfn
       #
       # @return [String]
       def prompt_for_code
-        result = ui.ask 'AWS MFA code', :valid => /^\d{6}$/
+        result = ui.ask "AWS MFA code", :valid => /^\d{6}$/
         result.strip
       end
     end

--- a/lib/sfn/callback/stack_policy.rb
+++ b/lib/sfn/callback/stack_policy.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Callback
@@ -6,11 +6,11 @@ module Sfn
 
       # Policy to apply prior to stack deletion
       DEFENSELESS_POLICY = {
-        'Statement' => [{
-          'Effect' => 'Allow',
-          'Action' => 'Update:*',
-          'Resource' => '*',
-          'Principal' => '*',
+        "Statement" => [{
+          "Effect" => "Allow",
+          "Action" => "Update:*",
+          "Resource" => "*",
+          "Principal" => "*",
         }],
       }
 
@@ -29,14 +29,14 @@ module Sfn
       #
       # @param args [Hash]
       def submit_policy(args)
-        ui.info 'Submitting stack policy documents'
+        ui.info "Submitting stack policy documents"
         stack = args[:api_stack]
         ([stack] + stack.nested_stacks).compact.each do |p_stack|
           run_action "Applying stack policy to #{ui.color(p_stack.name, :yellow)}" do
             save_stack_policy(p_stack)
           end
         end
-        ui.info 'Stack policy documents successfully submitted!'
+        ui.info "Stack policy documents successfully submitted!"
       end
 
       alias_method :after_create, :submit_policy
@@ -46,8 +46,8 @@ module Sfn
       #
       # @param args [Hash]
       def before_update(args)
-        if config.get(:stack_policy, :update).to_s == 'defenseless'
-          ui.warn 'Disabling all stack policies for update.'
+        if config.get(:stack_policy, :update).to_s == "defenseless"
+          ui.warn "Disabling all stack policies for update."
           stack = args[:api_stack]
           ([stack] + stack.nested_stacks).compact.each do |p_stack|
             @policies[p_stack.name] = DEFENSELESS_POLICY
@@ -64,7 +64,7 @@ module Sfn
       # @param info [Hash]
       def template(info)
         if info[:sparkle_stack]
-          @policies.set(info.fetch(:stack_name, 'unknown'),
+          @policies.set(info.fetch(:stack_name, "unknown"),
                         info[:sparkle_stack].generate_policy)
         end
       end
@@ -89,12 +89,12 @@ module Sfn
           end
         end
         result = p_stack.api.request(
-          :path => '/',
+          :path => "/",
           :method => :post,
           :form => Smash.new(
-            'Action' => 'SetStackPolicy',
-            'StackName' => p_stack.id,
-            'StackPolicyBody' => MultiJson.dump(stack_policy),
+            "Action" => "SetStackPolicy",
+            "StackName" => p_stack.id,
+            "StackPolicyBody" => MultiJson.dump(stack_policy),
           ),
         )
       end

--- a/lib/sfn/command.rb
+++ b/lib/sfn/command.rb
@@ -1,53 +1,53 @@
-require 'sfn'
-require 'bogo-cli'
+require "sfn"
+require "bogo-cli"
 
 module Sfn
   class Command < Bogo::Cli::Command
     include CommandModule::Callbacks
 
-    autoload :Conf, 'sfn/command/conf'
-    autoload :Create, 'sfn/command/create'
-    autoload :Describe, 'sfn/command/describe'
-    autoload :Destroy, 'sfn/command/destroy'
-    autoload :Diff, 'sfn/command/diff'
-    autoload :Events, 'sfn/command/events'
-    autoload :Export, 'sfn/command/export'
-    autoload :Graph, 'sfn/command/graph'
-    autoload :Import, 'sfn/command/import'
-    autoload :Init, 'sfn/command/init'
-    autoload :Inspect, 'sfn/command/inspect'
-    autoload :Lint, 'sfn/command/lint'
-    autoload :List, 'sfn/command/list'
-    autoload :Print, 'sfn/command/print'
-    autoload :Promote, 'sfn/command/promote'
-    autoload :Update, 'sfn/command/update'
-    autoload :Validate, 'sfn/command/validate'
+    autoload :Conf, "sfn/command/conf"
+    autoload :Create, "sfn/command/create"
+    autoload :Describe, "sfn/command/describe"
+    autoload :Destroy, "sfn/command/destroy"
+    autoload :Diff, "sfn/command/diff"
+    autoload :Events, "sfn/command/events"
+    autoload :Export, "sfn/command/export"
+    autoload :Graph, "sfn/command/graph"
+    autoload :Import, "sfn/command/import"
+    autoload :Init, "sfn/command/init"
+    autoload :Inspect, "sfn/command/inspect"
+    autoload :Lint, "sfn/command/lint"
+    autoload :List, "sfn/command/list"
+    autoload :Print, "sfn/command/print"
+    autoload :Promote, "sfn/command/promote"
+    autoload :Update, "sfn/command/update"
+    autoload :Validate, "sfn/command/validate"
 
     # Base name of configuration file
-    CONFIG_BASE_NAME = '.sfn'
+    CONFIG_BASE_NAME = ".sfn"
 
     # Supported configuration file extensions
     VALID_CONFIG_EXTENSIONS = [
-      '',
-      '.rb',
-      '.json',
-      '.yaml',
-      '.yml',
-      '.xml',
+      "",
+      ".rb",
+      ".json",
+      ".yaml",
+      ".yml",
+      ".xml",
     ]
 
     # Override to provide config file searching
     def initialize(cli_opts, args)
-      unless cli_opts['config']
+      unless cli_opts["config"]
         discover_config(cli_opts)
       end
-      unless ENV['DEBUG']
-        ENV['DEBUG'] = 'true' if cli_opts[:debug]
+      unless ENV["DEBUG"]
+        ENV["DEBUG"] = "true" if cli_opts[:debug]
       end
       super(cli_opts, args)
       load_api_provider_extensions!
       run_callbacks_for(:after_config)
-      run_callbacks_for("after_config_#{Bogo::Utility.snake(self.class.name.split('::').last)}")
+      run_callbacks_for("after_config_#{Bogo::Utility.snake(self.class.name.split("::").last)}")
     end
 
     # @return [Smash]
@@ -65,7 +65,7 @@ module Sfn
     def load_api_provider_extensions!
       if config.get(:credentials, :provider)
         base_ext = Bogo::Utility.camel(config.get(:credentials, :provider)).to_sym
-        targ_ext = self.class.name.split('::').last
+        targ_ext = self.class.name.split("::").last
         if ApiProvider.constants.include?(base_ext)
           base_module = ApiProvider.const_get(base_ext)
           ui.debug "Loading core provider extensions via `#{base_module}`"
@@ -87,26 +87,26 @@ module Sfn
     # @return [Slop]
     def discover_config(opts)
       cwd = Dir.pwd.split(File::SEPARATOR)
-      detected_path = ''
+      detected_path = ""
       until cwd.empty? || File.exists?(detected_path.to_s)
         detected_path = Dir.glob(
-          (cwd + ["#{CONFIG_BASE_NAME}{#{VALID_CONFIG_EXTENSIONS.join(',')}}"]).join(
+          (cwd + ["#{CONFIG_BASE_NAME}{#{VALID_CONFIG_EXTENSIONS.join(",")}}"]).join(
             File::SEPARATOR
           )
         ).first
         cwd.pop
       end
       if opts.respond_to?(:fetch_option)
-        opts.fetch_option('config').value = detected_path if detected_path
+        opts.fetch_option("config").value = detected_path if detected_path
       else
-        opts['config'] = detected_path if detected_path
+        opts["config"] = detected_path if detected_path
       end
       opts
     end
 
     # @return [Class] attempt to return customized configuration class
     def config_class
-      klass_name = self.class.name.split('::').last
+      klass_name = self.class.name.split("::").last
       if Sfn::Config.const_defined?(klass_name)
         Sfn::Config.const_get(klass_name)
       else

--- a/lib/sfn/command/conf.rb
+++ b/lib/sfn/command/conf.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command
@@ -12,42 +12,42 @@ module Sfn
         Config::Conf.attributes.sort_by(&:first).each do |k, val|
           if config.has_key?(k)
             ui.print "  #{ui.color(k, :bold, :green)}: "
-            format_value(config[k], '  ')
+            format_value(config[k], "  ")
           end
         end
         if config[:generate]
           ui.puts
-          ui.info 'Generating .sfn configuration file..'
+          ui.info "Generating .sfn configuration file.."
           generate_config!
-          ui.info "Generation of .sfn configuration file #{ui.color('complete!', :green, :bold)}"
+          ui.info "Generation of .sfn configuration file #{ui.color("complete!", :green, :bold)}"
         end
       end
 
       def generate_config!
-        if File.exists?('.sfn')
-          ui.warn 'Existing .sfn configuration file detected!'
-          ui.confirm 'Overwrite current .sfn configuration file?'
+        if File.exists?(".sfn")
+          ui.warn "Existing .sfn configuration file detected!"
+          ui.confirm "Overwrite current .sfn configuration file?"
         end
-        run_action 'Writing .sfn file' do
-          File.open('.sfn', 'w') do |file|
+        run_action "Writing .sfn file" do
+          File.open(".sfn", "w") do |file|
             file.write SFN_CONFIG_CONTENTS
           end
           nil
         end
       end
 
-      def format_value(value, indent = '')
+      def format_value(value, indent = "")
         if value.is_a?(Hash)
           ui.puts
           value.sort_by(&:first).each do |k, v|
             ui.print "#{indent}  #{ui.color(k, :bold)}: "
-            format_value(v, indent + '  ')
+            format_value(v, indent + "  ")
           end
         elsif value.is_a?(Array)
           ui.puts
           value.map(&:to_s).sort.each do |v|
             ui.print "#{indent}  "
-            format_value(v, indent + '  ')
+            format_value(v, indent + "  ")
           end
         else
           ui.puts value.to_s

--- a/lib/sfn/command/create.rb
+++ b/lib/sfn/command/create.rb
@@ -1,5 +1,5 @@
-require 'sparkle_formation'
-require 'sfn'
+require "sparkle_formation"
+require "sfn"
 
 module Sfn
   class Command
@@ -24,12 +24,12 @@ module Sfn
         end
 
         unless config[:print_only]
-          ui.info "#{ui.color('SparkleFormation:', :bold)} #{ui.color('create', :green)}"
+          ui.info "#{ui.color("SparkleFormation:", :bold)} #{ui.color("create", :green)}"
         end
 
-        stack_info = "#{ui.color('Name:', :bold)} #{name}"
+        stack_info = "#{ui.color("Name:", :bold)} #{name}"
         if config[:path]
-          stack_info << " #{ui.color('Path:', :bold)} #{config[:file]}"
+          stack_info << " #{ui.color("Path:", :bold)} #{config[:file]}"
         end
 
         if config[:print_only]
@@ -66,14 +66,14 @@ module Sfn
             stack = provider.stack(name)
 
             if stack.reload.state == :create_complete
-              ui.info "Stack create complete: #{ui.color('SUCCESS', :green)}"
+              ui.info "Stack create complete: #{ui.color("SUCCESS", :green)}"
               namespace.const_get(:Describe).new({:outputs => true}, [name]).execute!
             else
-              ui.fatal "Create of new stack #{ui.color(name, :bold)}: #{ui.color('FAILED', :red, :bold)}"
-              raise 'Stack did not reach a successful completion state.'
+              ui.fatal "Create of new stack #{ui.color(name, :bold)}: #{ui.color("FAILED", :red, :bold)}"
+              raise "Stack did not reach a successful completion state."
             end
           else
-            ui.warn 'Stack state polling has been disabled.'
+            ui.warn "Stack state polling has been disabled."
             ui.info "Stack creation initialized for #{ui.color(name, :green)}"
           end
         end

--- a/lib/sfn/command/describe.rb
+++ b/lib/sfn/command/describe.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command
@@ -75,11 +75,11 @@ module Sfn
         unless stack.outputs.nil? || stack.outputs.empty?
           stack.outputs.each do |output|
             key, value = output.key, output.value
-            key = snake(key).to_s.split('_').map(&:capitalize).join(' ')
-            ui.info ['  ', ui.color("#{key}:", :bold), value].join(' ')
+            key = snake(key).to_s.split("_").map(&:capitalize).join(" ")
+            ui.info ["  ", ui.color("#{key}:", :bold), value].join(" ")
           end
         else
-          ui.info "  #{ui.color('No outputs found')}"
+          ui.info "  #{ui.color("No outputs found")}"
         end
       end
 
@@ -90,10 +90,10 @@ module Sfn
         ui.info "Tags for stack: #{ui.color(stack.name, :bold)}"
         if stack.tags && !stack.tags.empty?
           stack.tags.each do |key, value|
-            ui.info ['  ', ui.color("#{key}:", :bold), value].join(' ')
+            ui.info ["  ", ui.color("#{key}:", :bold), value].join(" ")
           end
         else
-          ui.info "  #{ui.color('No tags found')}"
+          ui.info "  #{ui.color("No tags found")}"
         end
       end
 

--- a/lib/sfn/command/destroy.rb
+++ b/lib/sfn/command/destroy.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command
@@ -9,7 +9,7 @@ module Sfn
       def execute!
         name_required!
         stacks = name_args.sort
-        plural = 's' if stacks.size > 1
+        plural = "s" if stacks.size > 1
         globs = stacks.find_all do |s|
           s !~ /^[a-zA-Z0-9-]+$/
         end
@@ -23,7 +23,7 @@ module Sfn
           stacks -= globs
           stacks.sort!
         end
-        ui.warn "Destroying Stack#{plural}: #{ui.color(stacks.join(', '), :bold)}"
+        ui.warn "Destroying Stack#{plural}: #{ui.color(stacks.join(", "), :bold)}"
         ui.confirm "Destroy listed stack#{plural}?"
         stacks.each do |stack_name|
           stack = provider.connection.stacks.get(stack_name)
@@ -56,7 +56,7 @@ module Sfn
             ui.error "Stack polling is not available when multiple stack deletion is requested!"
           end
         end
-        ui.info "  -> Destroyed SparkleFormation#{plural}: #{ui.color(stacks.join(', '), :bold, :red)}"
+        ui.info "  -> Destroyed SparkleFormation#{plural}: #{ui.color(stacks.join(", "), :bold, :red)}"
       end
 
       # Cleanup persisted templates if nested stack resources are included
@@ -64,12 +64,12 @@ module Sfn
         stack.nested_stacks.each do |n_stack|
           nested_stack_cleanup!(n_stack)
         end
-        nest_stacks = stack.template.fetch('Resources', {}).values.find_all do |resource|
-          provider.connection.data[:stack_types].include?(resource['Type'])
+        nest_stacks = stack.template.fetch("Resources", {}).values.find_all do |resource|
+          provider.connection.data[:stack_types].include?(resource["Type"])
         end.each do |resource|
-          url = resource['Properties']['TemplateURL']
+          url = resource["Properties"]["TemplateURL"]
           if url && url.is_a?(String)
-            _, bucket_name, path = URI.parse(url).path.split('/', 3)
+            _, bucket_name, path = URI.parse(url).path.split("/", 3)
             bucket = provider.connection.api_for(:storage).buckets.get(bucket_name)
             if bucket
               file = bucket.files.get(path)

--- a/lib/sfn/command/diff.rb
+++ b/lib/sfn/command/diff.rb
@@ -1,6 +1,6 @@
-require 'sparkle_formation'
-require 'sfn'
-require 'hashdiff'
+require "sparkle_formation"
+require "sfn"
+require "hashdiff"
 
 module Sfn
   class Command
@@ -26,7 +26,7 @@ module Sfn
           file = load_template_file
           file = parameter_scrub!(file.dump)
 
-          ui.info "#{ui.color('SparkleFormation:', :bold)} #{ui.color('diff', :blue)} - #{name}"
+          ui.info "#{ui.color("SparkleFormation:", :bold)} #{ui.color("diff", :blue)} - #{name}"
           ui.puts
 
           diff_stack(stack, MultiJson.load(MultiJson.dump(file)).to_smash)
@@ -40,8 +40,8 @@ module Sfn
       def diff_stack(stack, file, parent_names = [])
         stack_template = stack.template
         nested_stacks = Hash[
-          file.fetch('Resources', file.fetch('resources', {})).find_all do |name, value|
-            value.fetch('Properties', {})['Stack']
+          file.fetch("Resources", file.fetch("resources", {})).find_all do |name, value|
+            value.fetch("Properties", {})["Stack"]
           end
         ]
         nested_stacks.each do |name, value|
@@ -49,58 +49,58 @@ module Sfn
             ns.data[:logical_id] == name
           end
           if n_stack
-            diff_stack(n_stack, value['Properties']['Stack'], [*parent_names, stack.data.fetch(:logical_id, stack.name)].compact)
+            diff_stack(n_stack, value["Properties"]["Stack"], [*parent_names, stack.data.fetch(:logical_id, stack.name)].compact)
           end
-          file['Resources'][name]['Properties'].delete('Stack')
+          file["Resources"][name]["Properties"].delete("Stack")
         end
 
-        ui.info "#{ui.color('Stack diff:', :bold)} #{ui.color((parent_names + [stack.data.fetch(:logical_id, stack.name)]).compact.join(' > '), :blue)}"
+        ui.info "#{ui.color("Stack diff:", :bold)} #{ui.color((parent_names + [stack.data.fetch(:logical_id, stack.name)]).compact.join(" > "), :blue)}"
 
         stack_diff = HashDiff.diff(stack.template, file)
 
         if config[:raw_diff]
           ui.info "Dumping raw template diff:"
-          require 'pp'
+          require "pp"
           pp stack_diff
         else
           added_resources = stack_diff.find_all do |item|
-            item.first == '+' && item[1].match(/Resources\.[^.]+$/)
+            item.first == "+" && item[1].match(/Resources\.[^.]+$/)
           end
           removed_resources = stack_diff.find_all do |item|
-            item.first == '-' && item[1].match(/Resources\.[^.]+$/)
+            item.first == "-" && item[1].match(/Resources\.[^.]+$/)
           end
           modified_resources = stack_diff.find_all do |item|
-            item[1].start_with?('Resources.') &&
-              !item[1].end_with?('TemplateURL') &&
-              !item[1].include?('Properties.Parameters')
+            item[1].start_with?("Resources.") &&
+              !item[1].end_with?("TemplateURL") &&
+              !item[1].include?("Properties.Parameters")
           end - added_resources - removed_resources
 
           if added_resources.empty? && removed_resources.empty? && modified_resources.empty?
-            ui.info 'No changes detected'
+            ui.info "No changes detected"
             ui.puts
           else
             unless added_resources.empty?
-              ui.info ui.color('Added Resources:', :green, :bold)
+              ui.info ui.color("Added Resources:", :green, :bold)
               added_resources.each do |item|
-                ui.print ui.color("  -> #{item[1].split('.').last}", :green)
-                ui.puts " [#{item[2]['Type']}]"
+                ui.print ui.color("  -> #{item[1].split(".").last}", :green)
+                ui.puts " [#{item[2]["Type"]}]"
               end
               ui.puts
             end
 
             unless modified_resources.empty?
-              ui.info ui.color('Modified Resources:', :yellow, :bold)
+              ui.info ui.color("Modified Resources:", :yellow, :bold)
               m_resources = Hash.new.tap do |hash|
                 modified_resources.each do |item|
-                  _, key, path = item[1].split('.', 3)
+                  _, key, path = item[1].split(".", 3)
                   hash[key] ||= {}
-                  prefix, a_key = path.split('.', 2)
+                  prefix, a_key = path.split(".", 2)
                   hash[key][prefix] ||= []
                   matched = hash[key][prefix].detect do |i|
                     i[:path] == a_key
                   end
                   if matched
-                    if item.first == '-'
+                    if item.first == "-"
                       matched[:original] = item[2]
                     else
                       matched[:new] = item[2]
@@ -109,10 +109,10 @@ module Sfn
                     hash[key][prefix] << Hash.new.tap do |info|
                       info[:path] = a_key
                       case item.first
-                      when '~'
+                      when "~"
                         info[:original] = item[2]
                         info[:new] = item[3]
-                      when '+'
+                      when "+"
                         info[:new] = item[2]
                       else
                         info[:original] = item[2]
@@ -121,12 +121,12 @@ module Sfn
                   end
                 end
               end.to_smash(:sorted).each do |key, value|
-                ui.puts ui.color("  - #{key}", :yellow) + " [#{stack.template['Resources'][key]['Type']}]"
+                ui.puts ui.color("  - #{key}", :yellow) + " [#{stack.template["Resources"][key]["Type"]}]"
                 value.each do |prefix, items|
                   ui.puts ui.color("    #{prefix}:", :bold)
                   items.each do |item|
-                    original = item[:original].nil? ? ui.color('(none)', :yellow) : ui.color(item[:original].inspect, :red)
-                    new_val = item[:new].nil? ? ui.color('(deleted)', :red) : ui.color(item[:new].inspect, :green)
+                    original = item[:original].nil? ? ui.color("(none)", :yellow) : ui.color(item[:original].inspect, :red)
+                    new_val = item[:new].nil? ? ui.color("(deleted)", :red) : ui.color(item[:new].inspect, :green)
                     ui.puts "      #{item[:path]}: #{original} -> #{new_val}"
                   end
                 end
@@ -135,10 +135,10 @@ module Sfn
             end
 
             unless removed_resources.empty?
-              ui.info ui.color('Removed Resources:', :red, :bold)
+              ui.info ui.color("Removed Resources:", :red, :bold)
               removed_resources.each do |item|
-                ui.print ui.color("  <- #{item[1].split('.').last}", :red)
-                ui.puts " [#{item[2]['Type']}]"
+                ui.print ui.color("  <- #{item[1].split(".").last}", :red)
+                ui.puts " [#{item[2]["Type"]}]"
               end
               ui.puts
             end

--- a/lib/sfn/command/events.rb
+++ b/lib/sfn/command/events.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command
@@ -25,7 +25,7 @@ module Sfn
                   allowed_attributes.each do |attr|
                     width_val = events.map { |e| e[attr].to_s.length }.push(attr.length).max + 2
                     width_val = width_val > 70 ? 70 : width_val < 20 ? 20 : width_val
-                    column attr.split('_').map(&:capitalize).join(' '), :width => width_val
+                    column attr.split("_").map(&:capitalize).join(" "), :width => width_val
                   end
                 end
                 events.each do |event|
@@ -70,7 +70,7 @@ module Sfn
               i_events = i_stack.events.all
             end
           rescue => e
-            if e.class.to_s.start_with?('Errno')
+            if e.class.to_s.start_with?("Errno")
               ui.warn "Connection error encountered: #{e.message} (retrying)"
               ui.debug "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
             else
@@ -93,8 +93,8 @@ module Sfn
           unless config[:all_events]
             start_index = stack_events.rindex do |item|
               item[:stack_name] == stack.name &&
-                item[:resource_state].to_s.end_with?('in_progress') &&
-                item[:resource_status_reason].to_s.downcase.include?('user init')
+                item[:resource_state].to_s.end_with?("in_progress") &&
+                item[:resource_status_reason].to_s.downcase.include?("user init")
             end
             if start_index
               stack_events.slice!(0, start_index)
@@ -121,7 +121,7 @@ module Sfn
       def allowed_attributes
         result = super
         unless @stacks.size > 1
-          result.delete('stack_name')
+          result.delete("stack_name")
         end
         result
       end

--- a/lib/sfn/command/export.rb
+++ b/lib/sfn/command/export.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command
@@ -9,10 +9,10 @@ module Sfn
 
       # Run export action
       def execute!
-        raise NotImplementedError.new 'Implementation updates required'
+        raise NotImplementedError.new "Implementation updates required"
         stack_name = name_args.first
-        ui.info "#{ui.color('Stack Export:', :bold)} #{stack_name}"
-        ui.confirm 'Perform export'
+        ui.info "#{ui.color("Stack Export:", :bold)} #{stack_name}"
+        ui.confirm "Perform export"
         stack = provider.stacks.get(stack_name)
         if stack
           export_options = Smash.new.tap do |opts|
@@ -27,10 +27,10 @@ module Sfn
             write_to_bucket(result, stack),
           ].compact
           if outputs.empty?
-            ui.warn 'No persistent output location defined. Printing export:'
+            ui.warn "No persistent output location defined. Printing export:"
             ui.info _format_json(result)
           end
-          ui.info "#{ui.color('Stack export', :bold)} (#{name_args.first}): #{ui.color('complete', :green)}"
+          ui.info "#{ui.color("Stack export", :bold)} (#{name_args.first}): #{ui.color("complete", :green)}"
           unless outputs.empty?
             outputs.each do |output|
               ui.info ui.color("  -> #{output}", :blue)
@@ -71,10 +71,10 @@ module Sfn
             config[:path],
             export_file_name(stack)
           )
-          _, bucket, path = full_path.split('/', 3)
+          _, bucket, path = full_path.split("/", 3)
           directory = provider.service_for(:storage,
                                            :provider => :local,
-                                           :local_root => '/').directories.get(bucket)
+                                           :local_root => "/").directories.get(bucket)
           file_store(payload, path, directory)
         end
       end

--- a/lib/sfn/command/graph.rb
+++ b/lib/sfn/command/graph.rb
@@ -1,11 +1,11 @@
-require 'sfn'
-require 'graph'
+require "sfn"
+require "graph"
 
 module Sfn
   class Command
     # Graph command
     class Graph < Command
-      autoload :Provider, 'sfn/command/graph/provider'
+      autoload :Provider, "sfn/command/graph/provider"
 
       include Sfn::CommandModule::Base
       include Sfn::CommandModule::Template
@@ -13,8 +13,8 @@ module Sfn
 
       # Valid graph styles
       GRAPH_STYLES = [
-        'creation',
-        'dependency',
+        "creation",
+        "dependency",
       ]
 
       # Generate graph
@@ -33,23 +33,23 @@ module Sfn
             ui.puts "  -> path: #{config[:file]}"
           end
           template_dump = file.compile.sparkle_dump!.to_smash
-          run_action 'Pre-processing template for graphing' do
+          run_action "Pre-processing template for graphing" do
             output_discovery(template_dump, @outputs, nil, nil)
-            ui.debug 'Output remapping results from pre-processing:'
+            ui.debug "Output remapping results from pre-processing:"
             @outputs.each_pair do |o_key, o_value|
               ui.debug "#{o_key} -> #{o_value}"
             end
             nil
           end
           graph = nil
-          run_action 'Generating resource graph' do
+          run_action "Generating resource graph" do
             graph = generate_graph(template_dump)
             nil
           end
-          run_action 'Writing graph result' do
+          run_action "Writing graph result" do
             FileUtils.mkdir_p(File.dirname(config[:output_file]))
-            if config[:output_type] == 'dot'
-              File.open("#{config[:output_file]}.dot", 'w') do |o_file|
+            if config[:output_type] == "dot"
+              File.open("#{config[:output_file]}.dot", "w") do |o_file|
                 o_file.puts graph.to_s
               end
             else
@@ -60,7 +60,7 @@ module Sfn
         else
           valid_providers = Provider.constants.sort.map { |provider|
             Bogo::Utility.snake(provider)
-          }.join('`, `')
+          }.join("`, `")
           ui.error "Graphing for provider `#{file.provider}` not currently supported."
           ui.error "Currently supported providers: `#{valid_providers}`."
         end
@@ -69,9 +69,9 @@ module Sfn
       def generate_graph(template, args = {})
         graph = ::Graph.new
         @root_graph = graph unless @root_graph
-        graph.graph_attribs << ::Graph::Attribute.new('overlap = false')
-        graph.graph_attribs << ::Graph::Attribute.new('splines = true')
-        graph.graph_attribs << ::Graph::Attribute.new('pack = true')
+        graph.graph_attribs << ::Graph::Attribute.new("overlap = false")
+        graph.graph_attribs << ::Graph::Attribute.new("splines = true")
+        graph.graph_attribs << ::Graph::Attribute.new("pack = true")
         graph.graph_attribs << ::Graph::Attribute.new('start = "random"')
         if args[:name]
           graph.name = "cluster_#{args[:name]}"
@@ -79,9 +79,9 @@ module Sfn
           graph.plaintext << graph.node(labelnode_key)
           graph.node(labelnode_key).label args[:name]
         else
-          graph.name = 'root'
+          graph.name = "root"
         end
-        edge_detection(template, graph, args[:name].to_s.sub('cluster_', ''), args.fetch(:resource_names, []))
+        edge_detection(template, graph, args[:name].to_s.sub("cluster_", ""), args.fetch(:resource_names, []))
         graph
       end
 
@@ -93,7 +93,7 @@ module Sfn
             memo + chr.ord
           end
         end
-        color = '#'
+        color = "#"
         3.times do |i|
           color << (255 ^ hash).to_s(16)
           new_val = hash + (hash * (1 / (i + 1.to_f))).to_i
@@ -108,12 +108,12 @@ module Sfn
 
       def validate_graph_style!
         if config[:luckymike]
-          ui.warn 'Detected luckymike power override. Forcing `dependency` style!'
-          config[:graph_style] = 'dependency'
+          ui.warn "Detected luckymike power override. Forcing `dependency` style!"
+          config[:graph_style] = "dependency"
         end
         config[:graph_style] = config[:graph_style].to_s
         unless GRAPH_STYLES.include?(config[:graph_style])
-          raise ArgumentError.new "Invalid graph style provided `#{config[:graph_style]}`. Valid: `#{GRAPH_STYLES.join('`, `')}`"
+          raise ArgumentError.new "Invalid graph style provided `#{config[:graph_style]}`. Valid: `#{GRAPH_STYLES.join("`, `")}`"
         end
       end
     end

--- a/lib/sfn/command/graph/provider.rb
+++ b/lib/sfn/command/graph/provider.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command

--- a/lib/sfn/command/import.rb
+++ b/lib/sfn/command/import.rb
@@ -1,5 +1,5 @@
-require 'stringio'
-require 'sfn'
+require "stringio"
+require "sfn"
 
 module Sfn
   class Command
@@ -12,27 +12,27 @@ module Sfn
 
       # Run the import action
       def execute!
-        raise NotImplementedError.new 'Implementation updates required'
+        raise NotImplementedError.new "Implementation updates required"
         stack_name, json_file = name_args
-        ui.info "#{ui.color('Stack Import:', :bold)} #{stack_name}"
+        ui.info "#{ui.color("Stack Import:", :bold)} #{stack_name}"
         unless json_file
           entries = [].tap do |_entries|
-            _entries.push('s3') if config[:bucket]
-            _entries.push('fs') if config[:path]
+            _entries.push("s3") if config[:bucket]
+            _entries.push("fs") if config[:path]
           end
           if entries.size > 1
             valid = false
             until valid
-              answer = ui.ask_question('Import via file system (fs) or remote bucket (remote)?', :default => 'remote')
+              answer = ui.ask_question("Import via file system (fs) or remote bucket (remote)?", :default => "remote")
               valid = true if %w(remote fs).include?(answer)
               entries = [answer]
             end
           elsif entries.size < 1
-            ui.fatal 'No path or bucket set. Unable to perform dynamic lookup!'
+            ui.fatal "No path or bucket set. Unable to perform dynamic lookup!"
             exit 1
           end
           case entries.first
-          when 'remote'
+          when "remote"
             json_file = remote_discovery
           else
             json_file = local_discovery
@@ -49,9 +49,9 @@ module Sfn
               ),
               [stack_name]
             )
-            ui.info '  - Starting creation of import'
+            ui.info "  - Starting creation of import"
             creator.execute!
-            ui.info "#{ui.color('Stack Import', :bold)} (#{json_file}): #{ui.color('complete', :green)}"
+            ui.info "#{ui.color("Stack Import", :bold)} (#{json_file}): #{ui.color("complete", :green)}"
           rescue => e
             ui.fatal "Failed to import stack: #{e}"
             debug "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
@@ -84,8 +84,8 @@ module Sfn
         directory = storage.directories.get(config[:bucket])
         file = prompt_for_file(
           directory,
-          :directories_name => 'Collections',
-          :files_names => 'Exports',
+          :directories_name => "Collections",
+          :files_names => "Exports",
           :filter_prefix => bucket_prefix,
         )
         if file
@@ -98,15 +98,15 @@ module Sfn
       #
       # @return [IO] stack export IO
       def local_discovery
-        _, bucket = config[:path].split('/', 2)
+        _, bucket = config[:path].split("/", 2)
         storage = provider.service_for(:storage,
                                        :provider => :local,
-                                       :local_root => '/')
+                                       :local_root => "/")
         directory = storage.directories.get(bucket)
         prompt_for_file(
           directory,
-          :directories_name => 'Collections',
-          :files_names => 'Exports',
+          :directories_name => "Collections",
+          :files_names => "Exports",
         )
       end
     end

--- a/lib/sfn/command/init.rb
+++ b/lib/sfn/command/init.rb
@@ -1,5 +1,5 @@
-require 'sfn'
-require 'fileutils'
+require "sfn"
+require "fileutils"
 
 module Sfn
   class Command
@@ -8,15 +8,15 @@ module Sfn
       include Sfn::CommandModule::Base
 
       INIT_DIRECTORIES = [
-        'sparkleformation/dynamics',
-        'sparkleformation/components',
-        'sparkleformation/registry',
+        "sparkleformation/dynamics",
+        "sparkleformation/components",
+        "sparkleformation/registry",
       ]
 
       # Run the init command to initialize new project
       def execute!
         unless name_args.size == 1
-          raise ArgumentError.new 'Please provide path argument only for project initialization'
+          raise ArgumentError.new "Please provide path argument only for project initialization"
         else
           path = name_args.first
         end
@@ -25,33 +25,33 @@ module Sfn
         end
         if File.directory?(path)
           ui.warn "Project directory already exists at given path. (`#{path}`)"
-          ui.confirm 'Overwrite existing files?'
+          ui.confirm "Overwrite existing files?"
         end
-        run_action 'Creating base project directories' do
+        run_action "Creating base project directories" do
           INIT_DIRECTORIES.each do |new_dir|
             FileUtils.mkdir_p(File.join(path, new_dir))
           end
           nil
         end
-        run_action 'Creating project bundle' do
-          File.open(File.join(path, 'Gemfile'), 'w') do |file|
+        run_action "Creating project bundle" do
+          File.open(File.join(path, "Gemfile"), "w") do |file|
             file.puts "source 'https://rubygems.org'\n\ngem 'sfn'"
           end
           nil
         end
-        ui.info 'Generating .sfn configuration file'
+        ui.info "Generating .sfn configuration file"
         Dir.chdir(path) do
           Conf.new({:generate => true}, []).execute!
         end
-        ui.info 'Installing project bundle'
+        ui.info "Installing project bundle"
         Dir.chdir(path) do
           if defined?(Bundler)
-            Bundler.clean_system('bundle install')
+            Bundler.clean_system("bundle install")
           else
-            system('bundle install')
+            system("bundle install")
           end
         end
-        ui.info 'Project initialization complete!'
+        ui.info "Project initialization complete!"
         ui.puts "  Project path -> #{File.expand_path(path)}"
       end
     end

--- a/lib/sfn/command/inspect.rb
+++ b/lib/sfn/command/inspect.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command
@@ -22,7 +22,7 @@ module Sfn
           end.compact
         end
         if outputs.empty?
-          ui.info '  Stack dump:'
+          ui.info "  Stack dump:"
           ui.puts MultiJson.dump(
             MultiJson.load(
               stack.reload.to_json
@@ -34,25 +34,25 @@ module Sfn
 
       def display_instance_failure(stack)
         instances = stack.resources.all.find_all do |resource|
-          resource.state.to_s.end_with?('failed')
+          resource.state.to_s.end_with?("failed")
         end.map do |resource|
           # If compute instance, simply expand
           if resource.within?(:compute, :servers)
             resource.instance
             # If a waitcondition, check for instance ID
-          elsif resource.type.to_s.downcase.end_with?('waitcondition')
-            if resource.status_reason.to_s.include?('uniqueId')
-              srv_id = resource.status_reason.split(' ').last.strip
+          elsif resource.type.to_s.downcase.end_with?("waitcondition")
+            if resource.status_reason.to_s.include?("uniqueId")
+              srv_id = resource.status_reason.split(" ").last.strip
               provider.connection.api_for(:compute).servers.get(srv_id)
             end
           end
         end.compact
         if instances.empty?
-          ui.error 'Failed to locate any failed instances'
+          ui.error "Failed to locate any failed instances"
         else
           log_path = config[:failure_log_path]
           if log_path.to_s.empty?
-            log_path = '/var/log/chef/client.log'
+            log_path = "/var/log/chef/client.log"
           end
           opts = ssh_key ? {:keys => [ssh_key]} : {}
           instances.each do |instance|
@@ -84,7 +84,7 @@ module Sfn
       #
       # @return [Array<String>] usernames for ssh connect attempt
       def ssh_attempt_users
-        [config[:ssh_user], config[:ssh_attempt_users], ENV['USER']].flatten.compact.uniq
+        [config[:ssh_user], config[:ssh_attempt_users], ENV["USER"]].flatten.compact.uniq
       end
 
       def ssh_key
@@ -93,14 +93,14 @@ module Sfn
 
       def display_attribute(stack)
         [config[:attribute]].flatten.compact.each do |stack_attribute|
-          attr = stack_attribute.split('.').inject(stack) do |memo, key|
+          attr = stack_attribute.split(".").inject(stack) do |memo, key|
             args = key.scan(/\(([^\)]*)\)/).flatten.first.to_s
             if args
-              args = args.split(',').map { |a| a.to_i.to_s == a ? a.to_i : a }
-              key = key.split('(').first
+              args = args.split(",").map { |a| a.to_i.to_s == a ? a.to_i : a }
+              key = key.split("(").first
             end
             if memo.public_methods.include?(key.to_sym)
-              if args.size == 1 && args.first.to_s.start_with?('&')
+              if args.size == 1 && args.first.to_s.start_with?("&")
                 memo.send(key, &args.first.slice(2, args.first.size).to_sym)
               else
                 memo.send(*[key, args].flatten.compact)
@@ -152,11 +152,11 @@ module Sfn
           end.compact
         ]
         unless asg_nodes.empty?
-          ui.info '  AutoScale Group Instances:'
+          ui.info "  AutoScale Group Instances:"
           ui.puts MultiJson.dump(asg_nodes, :pretty => true)
         end
         unless compute_nodes.empty?
-          ui.info '  Compute Instances:'
+          ui.info "  Compute Instances:"
           ui.puts MultiJson.dump(compute_nodes, :pretty => true)
         end
       end
@@ -179,7 +179,7 @@ module Sfn
           end
         ]
         unless load_balancers.empty?
-          ui.info '  Load Balancer Instances:'
+          ui.info "  Load Balancer Instances:"
           ui.puts MultiJson.dump(load_balancers, :pretty => true)
         end
       end

--- a/lib/sfn/command/lint.rb
+++ b/lib/sfn/command/lint.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command
@@ -12,7 +12,7 @@ module Sfn
         print_only_original = config[:print_only]
         config[:print_only] = true
         file = load_template_file
-        ui.info "#{ui.color("Template Linting (#{provider.connection.provider}): ", :bold)} #{config[:file].sub(Dir.pwd, '').sub(%r{^/}, '')}"
+        ui.info "#{ui.color("Template Linting (#{provider.connection.provider}): ", :bold)} #{config[:file].sub(Dir.pwd, "").sub(%r{^/}, "")}"
         config[:print_only] = print_only_original
 
         raw_template = parameter_scrub!(template_content(file))
@@ -22,16 +22,16 @@ module Sfn
         else
           result = lint_template(raw_template)
           if result == true
-            ui.info ui.color('  -> VALID', :green, :bold)
+            ui.info ui.color("  -> VALID", :green, :bold)
           else
-            ui.info ui.color('  -> INVALID', :red, :bold)
+            ui.info ui.color("  -> INVALID", :red, :bold)
             result.each do |failure|
               ui.error "Result Set: #{ui.color(failure[:rule_set].name, :red, :bold)}"
               failure[:failures].each do |f_msg|
                 ui.fatal f_msg
               end
             end
-            raise 'Linting failure'
+            raise "Linting failure"
           end
         end
       end
@@ -54,7 +54,7 @@ module Sfn
       def rule_sets
         sets = [config[:lint_directory]].flatten.compact.map do |directory|
           if File.directory?(directory)
-            files = Dir.glob(File.join(directory, '**', '**', '*.rb'))
+            files = Dir.glob(File.join(directory, "**", "**", "*.rb"))
             files.map do |path|
               begin
                 Sfn::Lint.class_eval(

--- a/lib/sfn/command/list.rb
+++ b/lib/sfn/command/list.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command
@@ -15,7 +15,7 @@ module Sfn
               allowed_attributes.each do |attr|
                 width_val = stacks.map { |e| e[attr].to_s.length }.push(attr.length).max + 2
                 width_val = width_val > 70 ? 70 : width_val < 20 ? 20 : width_val
-                column attr.split('_').map(&:capitalize).join(' '), :width => width_val
+                column attr.split("_").map(&:capitalize).join(" "), :width => width_val
               end
             end
             get_stacks.each do |stack|

--- a/lib/sfn/command/print.rb
+++ b/lib/sfn/command/print.rb
@@ -1,5 +1,5 @@
-require 'sparkle_formation'
-require 'sfn'
+require "sparkle_formation"
+require "sfn"
 
 module Sfn
   class Command
@@ -16,7 +16,7 @@ module Sfn
 
         output_content = parameter_scrub!(template_content(file))
         if config[:yaml]
-          require 'yaml'
+          require "yaml"
           output_content = YAML.dump(output_content)
         else
           output_content = format_json(output_content)
@@ -24,7 +24,7 @@ module Sfn
 
         if config[:write_to_file]
           unless File.directory?(File.dirname(config[:write_to_file]))
-            run_action 'Creating parent directory' do
+            run_action "Creating parent directory" do
               FileUtils.mkdir_p(File.dirname(config[:write_to_file]))
               nil
             end

--- a/lib/sfn/command/promote.rb
+++ b/lib/sfn/command/promote.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command
@@ -7,7 +7,7 @@ module Sfn
       include Sfn::CommandModule::Base
 
       def execute!
-        raise NotImplementedError.new 'Implementation updates required'
+        raise NotImplementedError.new "Implementation updates required"
         stack_name, destination = name_args
       end
     end

--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Command
@@ -13,7 +13,7 @@ module Sfn
         name_required!
         name = name_args.first
 
-        stack_info = "#{ui.color('Name:', :bold)} #{name}"
+        stack_info = "#{ui.color("Name:", :bold)} #{name}"
         begin
           stack = provider.stacks.get(name)
         rescue Miasma::Error::ApiError::RequestError
@@ -28,13 +28,13 @@ module Sfn
           c_setter = lambda do |c_stack|
             if c_stack.outputs
               compile_params = c_stack.outputs.detect do |output|
-                output.key == 'CompileState'
+                output.key == "CompileState"
               end
             end
             if compile_params
               compile_params = MultiJson.load(compile_params.value)
-              c_current = config[:compile_parameters].fetch(s_name.join('__'), Smash.new)
-              config[:compile_parameters][s_name.join('__')] = compile_params.merge(c_current)
+              c_current = config[:compile_parameters].fetch(s_name.join("__"), Smash.new)
+              config[:compile_parameters][s_name.join("__")] = compile_params.merge(c_current)
             end
             c_stack.nested_stacks(false).each do |n_stack|
               s_name.push(n_stack.data.fetch(:logical_id, n_stack.name))
@@ -49,7 +49,7 @@ module Sfn
 
           ui.debug "Compile parameters - #{config[:compile_parameters]}"
           file = load_template_file(:stack => stack)
-          stack_info << " #{ui.color('Path:', :bold)} #{config[:file]}"
+          stack_info << " #{ui.color("Path:", :bold)} #{config[:file]}"
         else
           file = stack.template.dup if config[:plan]
         end
@@ -60,15 +60,15 @@ module Sfn
         end
 
         unless config[:print_only]
-          ui.info "#{ui.color('SparkleFormation:', :bold)} #{ui.color('update', :green)}"
+          ui.info "#{ui.color("SparkleFormation:", :bold)} #{ui.color("update", :green)}"
         end
 
         unless file
           if config[:template]
             file = config[:template]
-            stack_info << " #{ui.color('(template provided)', :green)}"
+            stack_info << " #{ui.color("(template provided)", :green)}"
           else
-            stack_info << " #{ui.color('(no template update)', :yellow)}"
+            stack_info << " #{ui.color("(no template update)", :yellow)}"
           end
         end
         unless config[:print_only]
@@ -101,16 +101,16 @@ module Sfn
                 display_plan_information(result)
               end
             rescue => e
-              unless e.message.include?('Confirmation declined')
+              unless e.message.include?("Confirmation declined")
                 ui.error "Unexpected error when generating plan information: #{e.class} - #{e}"
                 ui.debug "#{e.class}: #{e}\n#{e.backtrace.join("\n")}"
-                ui.confirm 'Continue with stack update?' unless config[:plan_only]
+                ui.confirm "Continue with stack update?" unless config[:plan_only]
               else
                 raise
               end
             end
             if config[:plan_only]
-              ui.info 'Plan only mode requested. Exiting.'
+              ui.info "Plan only mode requested. Exiting."
               exit 0
             end
           end
@@ -144,19 +144,19 @@ module Sfn
             if config[:poll]
               poll_stack(stack.name)
               if stack.reload.state == :update_complete
-                ui.info "Stack update complete: #{ui.color('SUCCESS', :green)}"
+                ui.info "Stack update complete: #{ui.color("SUCCESS", :green)}"
                 namespace.const_get(:Describe).new({:outputs => true}, [name]).execute!
               else
-                ui.fatal "Update of stack #{ui.color(name, :bold)}: #{ui.color('FAILED', :red, :bold)}"
-                raise 'Stack did not reach a successful update completion state.'
+                ui.fatal "Update of stack #{ui.color(name, :bold)}: #{ui.color("FAILED", :red, :bold)}"
+                raise "Stack did not reach a successful update completion state."
               end
             else
-              ui.warn 'Stack state polling has been disabled.'
+              ui.warn "Stack state polling has been disabled."
               ui.info "Stack update initialized for #{ui.color(name, :green)}"
             end
           end
         rescue Miasma::Error::ApiError::RequestError => e
-          if e.message.downcase.include?('no updates')
+          if e.message.downcase.include?("no updates")
             ui.warn "No updates detected for stack (#{stack.name})"
           else
             raise
@@ -165,7 +165,7 @@ module Sfn
       end
 
       def build_planner(stack)
-        klass_name = stack.api.class.to_s.split('::').last
+        klass_name = stack.api.class.to_s.split("::").last
         if Planner.const_defined?(klass_name)
           Planner.const_get(klass_name).new(ui, config, arguments, stack)
         else
@@ -175,11 +175,11 @@ module Sfn
       end
 
       def display_plan_information(result)
-        ui.info ui.color('Pre-update resource planning report:', :bold)
+        ui.info ui.color("Pre-update resource planning report:", :bold)
         unless print_plan_result(result)
-          ui.info 'No resources life cycle changes detected in this update!'
+          ui.info "No resources life cycle changes detected in this update!"
         end
-        ui.confirm 'Apply this stack update?' unless config[:plan_only]
+        ui.confirm "Apply this stack update?" unless config[:plan_only]
       end
 
       def print_plan_result(info, names = [])
@@ -193,45 +193,45 @@ module Sfn
         unless names.flatten.compact.empty?
           said_things = false
           ui.puts
-          ui.puts "  #{ui.color('Update plan for:', :bold)} #{ui.color(names.join(' > '), :blue)}"
+          ui.puts "  #{ui.color("Update plan for:", :bold)} #{ui.color(names.join(" > "), :blue)}"
           unless info[:unknown].empty?
-            ui.puts "    #{ui.color('!!! Unknown update effect:', :red, :bold)}"
+            ui.puts "    #{ui.color("!!! Unknown update effect:", :red, :bold)}"
             print_plan_items(info, :unknown, :red)
             ui.puts
             said_any_things = said_things = true
           end
           unless info[:unavailable].empty?
-            ui.puts "    #{ui.color('Update request not allowed:', :red, :bold)}"
+            ui.puts "    #{ui.color("Update request not allowed:", :red, :bold)}"
             print_plan_items(info, :unavailable, :red)
             ui.puts
             said_any_things = said_things = true
           end
           unless info[:replace].empty?
-            ui.puts "    #{ui.color('Resources to be replaced:', :red, :bold)}"
+            ui.puts "    #{ui.color("Resources to be replaced:", :red, :bold)}"
             print_plan_items(info, :replace, :red)
             ui.puts
             said_any_things = said_things = true
           end
           unless info[:interrupt].empty?
-            ui.puts "    #{ui.color('Resources to be interrupted:', :yellow, :bold)}"
+            ui.puts "    #{ui.color("Resources to be interrupted:", :yellow, :bold)}"
             print_plan_items(info, :interrupt, :yellow)
             ui.puts
             said_any_things = said_things = true
           end
           unless info[:removed].empty?
-            ui.puts "    #{ui.color('Resources to be removed:', :red, :bold)}"
+            ui.puts "    #{ui.color("Resources to be removed:", :red, :bold)}"
             print_plan_items(info, :removed, :red)
             ui.puts
             said_any_things = said_things = true
           end
           unless info[:added].empty?
-            ui.puts "    #{ui.color('Resources to be added:', :green, :bold)}"
+            ui.puts "    #{ui.color("Resources to be added:", :green, :bold)}"
             print_plan_items(info, :added, :green)
             ui.puts
             said_any_things = said_things = true
           end
           unless said_things
-            ui.puts "    #{ui.color('No resource lifecycle changes detected!', :green)}"
+            ui.puts "    #{ui.color("No resource lifecycle changes detected!", :green)}"
             ui.puts
             said_any_things = true
           end
@@ -250,15 +250,15 @@ module Sfn
         max_p = info[key].values.map { |i| i.fetch(:diffs, []) }.flatten(1).map { |d| d.fetch(:property_name, :path).to_s.size }.max
         max_o = info[key].values.map { |i| i.fetch(:diffs, []) }.flatten(1).map { |d| d[:original].to_s.size }.max
         info[key].each do |name, val|
-          ui.print ' ' * 6
+          ui.print " " * 6
           ui.print ui.color("[#{val[:type]}]", color)
-          ui.print ' ' * (max_type - val[:type].size)
-          ui.print ' ' * 4
+          ui.print " " * (max_type - val[:type].size)
+          ui.print " " * 4
           ui.print ui.color(name, :bold)
           unless val[:properties].nil? || val[:properties].empty?
-            ui.print ' ' * (max_name - name.size)
-            ui.print ' ' * 4
-            ui.print "Reason: Updated properties: `#{val[:properties].join('`, `')}`"
+            ui.print " " * (max_name - name.size)
+            ui.print " " * 4
+            ui.print "Reason: Updated properties: `#{val[:properties].join("`, `")}`"
           end
           ui.puts
           if config[:diffs]
@@ -267,19 +267,19 @@ module Sfn
               val[:diffs].each do |diff|
                 if !diff[:updated].nil? || !diff[:original].nil?
                   p_name = diff.fetch(:property_name, :path)
-                  ui.print ' ' * 8
+                  ui.print " " * 8
                   ui.print "#{p_name}: "
-                  ui.print ' ' * (max_p - p_name.size)
+                  ui.print " " * (max_p - p_name.size)
                   ui.print ui.color("-#{diff[:original]}", :red) unless diff[:original].nil?
-                  ui.print ' ' * (max_o - diff[:original].to_s.size)
-                  ui.print ' '
+                  ui.print " " * (max_o - diff[:original].to_s.size)
+                  ui.print " "
                   if diff[:updated] == Sfn::Planner::RUNTIME_MODIFIED
                     ui.puts ui.color("+#{diff[:original]} <Dependency Modified>", :green)
                   else
                     if diff[:updated].nil?
                       ui.puts
                     else
-                      ui.puts ui.color("+#{diff[:updated].to_s.gsub('__MODIFIED_REFERENCE_VALUE__', '<Dependency Modified>')}", :green)
+                      ui.puts ui.color("+#{diff[:updated].to_s.gsub("__MODIFIED_REFERENCE_VALUE__", "<Dependency Modified>")}", :green)
                     end
                   end
                 end

--- a/lib/sfn/command/validate.rb
+++ b/lib/sfn/command/validate.rb
@@ -23,7 +23,11 @@ module Sfn
         else
           validate_stack(
             file.respond_to?(:dump) ? file.dump : file,
-            sparkle_collection.get(:template, config[:file])[:name]
+            if config[:processing]
+              sparkle_collection.get(:template, config[:file])[:name]
+            else
+              config[:file]
+            end
           )
         end
       end

--- a/lib/sfn/command/validate.rb
+++ b/lib/sfn/command/validate.rb
@@ -1,5 +1,5 @@
-require 'sparkle_formation'
-require 'sfn'
+require "sparkle_formation"
+require "sfn"
 
 module Sfn
   class Command
@@ -13,7 +13,7 @@ module Sfn
         print_only_original = config[:print_only]
         config[:print_only] = true
         file = load_template_file
-        ui.info "#{ui.color("Template Validation (#{provider.connection.provider}): ", :bold)} #{config[:file].sub(Dir.pwd, '').sub(%r{^/}, '')}"
+        ui.info "#{ui.color("Template Validation (#{provider.connection.provider}): ", :bold)} #{config[:file].sub(Dir.pwd, "").sub(%r{^/}, "")}"
         config[:print_only] = print_only_original
 
         raw_template = _format_json(parameter_scrub!(template_content(file)))
@@ -38,36 +38,36 @@ module Sfn
       # @param name [String] name of template
       # @return [TrueClass]
       def validate_stack(template, name)
-        resources = template.fetch('Resources', {})
+        resources = template.fetch("Resources", {})
         nested_stacks = resources.find_all do |r_name, r_value|
           r_value.is_a?(Hash) &&
-            provider.connection.data[:stack_types].include?(r_value['Type'])
+            provider.connection.data[:stack_types].include?(r_value["Type"])
         end
         nested_stacks.each do |n_name, n_resource|
-          validate_stack(n_resource.fetch('Properties', {}).fetch('Stack', {}), "#{name} > #{n_name}")
-          n_resource['Properties'].delete('Stack')
+          validate_stack(n_resource.fetch("Properties", {}).fetch("Stack", {}), "#{name} > #{n_name}")
+          n_resource["Properties"].delete("Stack")
         end
         begin
           ui.info "Validating: #{ui.color(name, :bold)}"
           if config[:upload_root_template]
-            upload_result = store_template('validation-stack', template, Smash.new)
+            upload_result = store_template("validation-stack", template, Smash.new)
             stack = provider.connection.stacks.build(
-              :name => 'validation-stack',
+              :name => "validation-stack",
               :template_url => upload_result[:url],
             )
           else
             stack = provider.connection.stacks.build(
-              :name => 'validation-stack',
+              :name => "validation-stack",
               :template => parameter_scrub!(template),
             )
           end
           result = api_action!(:api_stack => stack) do
             stack.validate
           end
-          ui.info ui.color('  -> VALID', :bold, :green)
+          ui.info ui.color("  -> VALID", :bold, :green)
           true
         rescue => e
-          ui.info ui.color('  -> INVALID', :bold, :red)
+          ui.info ui.color("  -> INVALID", :bold, :red)
           ui.fatal e.message
           raise e
         end

--- a/lib/sfn/command_module.rb
+++ b/lib/sfn/command_module.rb
@@ -1,10 +1,10 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module CommandModule
-    autoload :Base, 'sfn/command_module/base'
-    autoload :Callbacks, 'sfn/command_module/callbacks'
-    autoload :Stack, 'sfn/command_module/stack'
-    autoload :Template, 'sfn/command_module/template'
+    autoload :Base, "sfn/command_module/base"
+    autoload :Callbacks, "sfn/command_module/callbacks"
+    autoload :Stack, "sfn/command_module/stack"
+    autoload :Template, "sfn/command_module/template"
   end
 end

--- a/lib/sfn/command_module/base.rb
+++ b/lib/sfn/command_module/base.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module CommandModule
@@ -23,7 +23,7 @@ module Sfn
         # @param location [Symbol, String] name of location
         # @return [Sfn::Provider]
         def provider_for(location = nil)
-          key = ['provider', location].compact.map(&:to_s).join('_')
+          key = ["provider", location].compact.map(&:to_s).join("_")
           if location
             credentials = config.get(:locations, location)
             unless credentials
@@ -55,7 +55,7 @@ module Sfn
               result
             end
           rescue => e
-            ui.error 'Failed to create remote API connection. Please validate configuration!'
+            ui.error "Failed to create remote API connection. Please validate configuration!"
             ui.error "Connection failure reason - #{e.class} - #{e}"
             raise
           end
@@ -70,7 +70,7 @@ module Sfn
         def _debug(e, *args)
           if config[:verbose] || config[:debug]
             ui.fatal "Exception information: #{e.class}: #{e.message}"
-            if ENV['DEBUG'] || config[:debug]
+            if ENV["DEBUG"] || config[:debug]
               puts "#{e.backtrace.join("\n")}\n"
               if e.is_a?(Miasma::Error::ApiError)
                 ui.fatal "Response body: #{e.response.body.to_s.inspect}"
@@ -87,7 +87,7 @@ module Sfn
         # @param string [String, Symbol]
         # @return [String
         def as_title(string)
-          string.to_s.split('_').map(&:capitalize).join(' ')
+          string.to_s.split("_").map(&:capitalize).join(" ")
         end
 
         # Get stack
@@ -137,7 +137,7 @@ module Sfn
           begin
             yield
           rescue => e
-            ui.fatal "#{message || 'Failed to retrieve information'}#{" for requested stack: #{stack}" if stack}"
+            ui.fatal "#{message || "Failed to retrieve information"}#{" for requested stack: #{stack}" if stack}"
             ui.fatal "Reason: #{e}"
             _debug(e)
             exit 1
@@ -172,8 +172,8 @@ module Sfn
         # @raise [ArgumentError]
         def name_required!
           if name_args.empty?
-            ui.error 'Name argument must be provided!'
-            raise ArgumentError.new 'Missing required name argument'
+            ui.error "Name argument must be provided!"
+            raise ArgumentError.new "Missing required name argument"
           end
         end
       end

--- a/lib/sfn/command_module/callbacks.rb
+++ b/lib/sfn/command_module/callbacks.rb
@@ -1,5 +1,5 @@
-require 'sfn'
-require 'sparkle_formation'
+require "sfn"
+require "sparkle_formation"
 
 module Sfn
   module CommandModule
@@ -13,7 +13,7 @@ module Sfn
       # @yieldresult [Object] result from call
       # @return [Object] result of yield block
       def api_action!(*args)
-        type = self.class.name.split('::').last.downcase
+        type = self.class.name.split("::").last.downcase
         run_callbacks_for(["before_#{type}", :before], *args)
         result = nil
         begin
@@ -38,13 +38,13 @@ module Sfn
         end.flatten(1).compact.uniq.each do |item|
           callback_name, callback, quiet = item
           quiet = true if config[:print_only]
-          ui.info "Callback #{ui.color(type.to_s, :bold)} #{callback_name}: #{ui.color('starting', :yellow)}" unless quiet
+          ui.info "Callback #{ui.color(type.to_s, :bold)} #{callback_name}: #{ui.color("starting", :yellow)}" unless quiet
           if args.empty?
             callback.call
           else
             callback.call(*args)
           end
-          ui.info "Callback #{ui.color(type.to_s, :bold)} #{callback_name}: #{ui.color('complete', :green)}" unless quiet
+          ui.info "Callback #{ui.color(type.to_s, :bold)} #{callback_name}: #{ui.color("complete", :green)}" unless quiet
         end
         nil
       end

--- a/lib/sfn/command_module/stack.rb
+++ b/lib/sfn/command_module/stack.rb
@@ -1,5 +1,5 @@
-require 'sfn'
-require 'sparkle_formation'
+require "sfn"
+require "sparkle_formation"
 
 module Sfn
   module CommandModule
@@ -10,13 +10,13 @@ module Sfn
         # maximum number of attempts to get valid parameter value
         MAX_PARAMETER_ATTEMPTS = 5
         # Template parameter locations
-        TEMPLATE_PARAMETER_LOCATIONS = ['Parameters', 'parameters']
+        TEMPLATE_PARAMETER_LOCATIONS = ["Parameters", "parameters"]
         # Template parameter default value locations
-        TEMPLATE_PARAMETER_DEFAULTS = ['Default', 'defaultValue', 'default']
+        TEMPLATE_PARAMETER_DEFAULTS = ["Default", "defaultValue", "default"]
         # Template parameter no echo locations
-        TEMPLATE_PARAMETER_NOECHO = ['NoEcho']
+        TEMPLATE_PARAMETER_NOECHO = ["NoEcho"]
         # Template parameter no echo custom
-        TEMPLATE_PARAMETER_SFN_NOECHO = ['Quiet', 'quiet']
+        TEMPLATE_PARAMETER_SFN_NOECHO = ["Quiet", "quiet"]
 
         # Apply any defined remote stacks
         #
@@ -25,7 +25,7 @@ module Sfn
         def apply_stacks!(stack)
           remote_stacks = [config[:apply_stack]].flatten.compact
           remote_stacks.each do |stack_name|
-            stack_info = stack_name.split('__')
+            stack_info = stack_name.split("__")
             stack_info.unshift(nil) if stack_info.size == 1
             stack_location, stack_name = stack_info
             remote_stack = provider_for(stack_location).stack(stack_name)
@@ -66,7 +66,7 @@ module Sfn
           if config[:apply_mapping]
             valid_keys = config[:apply_mapping].keys.find_all do |a_key|
               a_key = a_key.to_s
-              key_parts = a_key.split('__')
+              key_parts = a_key.split("__")
               case key_parts.size
               when 3
                 provider_stack.api.data[:location] == key_parts[0] &&
@@ -85,7 +85,7 @@ module Sfn
             valid_keys -= to_remove
             Hash[
               valid_keys.map do |a_key|
-                cut_key = a_key.split('__').last
+                cut_key = a_key.split("__").last
                 [cut_key, config[:apply_mapping][a_key]]
               end
             ]
@@ -148,16 +148,16 @@ module Sfn
         # @param parameter_name [String] parameter name
         # @return [Array<String>] [expected_template_key, configuration_used_key]
         def locate_config_parameter_key(parameter_prefix, parameter_name, root_name)
-          check_name = parameter_name.downcase.tr('-_', '')
-          check_prefix = parameter_prefix.map { |i| i.downcase.tr('-_', '') }
+          check_name = parameter_name.downcase.tr("-_", "")
+          check_prefix = parameter_prefix.map { |i| i.downcase.tr("-_", "") }
           key_match = config[:parameters].keys.detect do |cp_key|
-            cp_key = cp_key.to_s.downcase.split('__').map { |i| i.tr('-_', '') }.join('__')
-            non_root_matcher = (check_prefix + [check_name]).join('__')
-            root_matcher = ([root_name] + check_prefix + [check_name]).join('__')
+            cp_key = cp_key.to_s.downcase.split("__").map { |i| i.tr("-_", "") }.join("__")
+            non_root_matcher = (check_prefix + [check_name]).join("__")
+            root_matcher = ([root_name] + check_prefix + [check_name]).join("__")
             cp_key == non_root_matcher ||
               cp_key == root_matcher
           end
-          actual_key = (parameter_prefix + [parameter_name]).compact.join('__')
+          actual_key = (parameter_prefix + [parameter_name]).compact.join("__")
           if key_match
             ui.debug "Remapping configuration runtime parameter `#{key_match}` -> `#{actual_key}`"
             config[:parameters][actual_key] = config[:parameters].delete(key_match)
@@ -179,9 +179,9 @@ module Sfn
           attempt = 0
           if !valid && !param_banner
             if sparkle.is_a?(SparkleFormation)
-              ui.info "#{ui.color('Stack runtime parameters:', :bold)} - template: #{ui.color(sparkle.root_path.map(&:name).map(&:to_s).join(' > '), :green, :bold)}"
+              ui.info "#{ui.color("Stack runtime parameters:", :bold)} - template: #{ui.color(sparkle.root_path.map(&:name).map(&:to_s).join(" > "), :green, :bold)}"
             else
-              ui.info ui.color('Stack runtime parameters:', :bold)
+              ui.info ui.color("Stack runtime parameters:", :bold)
             end
             param_banner = true
           end
@@ -194,17 +194,17 @@ module Sfn
             )
             if config[:interactive_parameters]
               no_echo = !!TEMPLATE_PARAMETER_NOECHO.detect { |loc_key|
-                param_value[loc_key].to_s.downcase == 'true'
+                param_value[loc_key].to_s.downcase == "true"
               }
               sfn_no_echo = TEMPLATE_PARAMETER_SFN_NOECHO.map do |loc_key|
                 res = param_value.delete(loc_key).to_s.downcase
-                res if !res.empty? && res != 'false'
+                res if !res.empty? && res != "false"
               end.compact.first
               no_echo = sfn_no_echo if sfn_no_echo
               answer = ui.ask_question(
-                "#{param_name.split(/([A-Z]+[^A-Z]*)/).find_all { |s| !s.empty? }.join(' ')}",
+                "#{param_name.split(/([A-Z]+[^A-Z]*)/).find_all { |s| !s.empty? }.join(" ")}",
                 :default => default,
-                :hide_default => sfn_no_echo == 'all',
+                :hide_default => sfn_no_echo == "all",
                 :no_echo => !!no_echo,
               )
             else
@@ -220,7 +220,7 @@ module Sfn
               end
             end
             if attempt > MAX_PARAMETER_ATTEMPTS
-              ui.fatal 'Failed to receive allowed parameter!'
+              ui.fatal "Failed to receive allowed parameter!"
               exit 1
             end
           end
@@ -279,8 +279,8 @@ module Sfn
           end
           Smash[
             config.fetch(:parameters, {}).map do |k, v|
-              strip_key = parameter_prefix ? k.sub(/#{parameter_prefix.join('__')}_{2}?/, '') : k
-              unless strip_key.include?('__')
+              strip_key = parameter_prefix ? k.sub(/#{parameter_prefix.join("__")}_{2}?/, "") : k
+              unless strip_key.include?("__")
                 [strip_key, v]
               end
             end.compact
@@ -299,7 +299,7 @@ module Sfn
         def config_root_parameters
           Hash[
             config.fetch(:parameters, {}).find_all do |k, v|
-              !k.include?('__')
+              !k.include?("__")
             end
           ]
         end
@@ -318,13 +318,13 @@ module Sfn
         def validate_stack_parameter(c_stack, p_key, p_ns_key, c_value)
           stack_value = c_stack.parameters[p_key]
           p_stack = c_stack.data[:parent_stack]
-          unless config[:parameter_validation] == 'none'
+          unless config[:parameter_validation] == "none"
             if c_value.is_a?(Hash)
               case c_value.keys.first
-              when 'Ref'
+              when "Ref"
                 current_value = p_stack.parameters[c_value.values.first]
-              when 'Fn::Att'
-                resource_name, output_name = c_value.values.first.split('.', 2)
+              when "Fn::Att"
+                resource_name, output_name = c_value.values.first.split(".", 2)
                 ref_stack = p_stack.nested_stacks.detect { |i| i.data[:logical_id] == resource_name }
                 if ref_stack
                   output = ref_stack.outputs.detect do |o|
@@ -339,14 +339,14 @@ module Sfn
               current_value = c_value
             end
             if current_value && current_value.to_s != stack_value.to_s
-              if config[:parameter_validation] == 'default'
-                ui.warn 'Nested stack has been altered directly! This update may cause unexpected modifications!'
+              if config[:parameter_validation] == "default"
+                ui.warn "Nested stack has been altered directly! This update may cause unexpected modifications!"
                 ui.warn "Stack name: #{c_stack.name}. Parameter: #{p_key}. Current value: #{stack_value}. Expected value: #{current_value} (via: #{c_value.inspect})"
-                answer = ui.ask_question("Use current value or expected value for #{p_key} [current/expected]?", :valid => ['current', 'expected'])
+                answer = ui.ask_question("Use current value or expected value for #{p_key} [current/expected]?", :valid => ["current", "expected"])
               else
                 answer = config[:parameter_validation]
               end
-              answer == 'expected'
+              answer == "expected"
             else
               true
             end

--- a/lib/sfn/command_module/template.rb
+++ b/lib/sfn/command_module/template.rb
@@ -1,7 +1,7 @@
-require 'sfn'
-require 'sparkle_formation'
+require "sfn"
+require "sparkle_formation"
 
-require 'pathname'
+require "pathname"
 
 module Sfn
   module CommandModule
@@ -48,7 +48,7 @@ module Sfn
         def request_compile_parameter(p_name, p_config, cur_val, nested = false)
           result = nil
           attempts = 0
-          parameter_type = p_config.fetch(:type, 'string').to_s.downcase.to_sym
+          parameter_type = p_config.fetch(:type, "string").to_s.downcase.to_sym
           if parameter_type == :complex
             ui.debug "Compile time parameter `#{p_name}` is a complex type. Not requesting value from user."
             if cur_val.nil?
@@ -61,13 +61,13 @@ module Sfn
               cur_val = p_config[:default]
             end
             if cur_val.is_a?(Array)
-              cur_val = cur_val.map(&:to_s).join(',')
+              cur_val = cur_val.map(&:to_s).join(",")
             end
             until result && (!result.respond_to?(:empty?) || !result.empty?)
               attempts += 1
               if config[:interactive_parameters] && (!nested || !p_config.key?(:prompt_when_nested) || p_config[:prompt_when_nested] == true)
                 result = ui.ask_question(
-                  p_name.to_s.split('_').map(&:capitalize).join,
+                  p_name.to_s.split("_").map(&:capitalize).join,
                   :default => cur_val.to_s.empty? ? nil : cur_val.to_s,
                 )
               else
@@ -76,11 +76,11 @@ module Sfn
               case parameter_type
               when :string
                 if p_config[:multiple]
-                  result = result.split(',').map(&:strip)
+                  result = result.split(",").map(&:strip)
                 end
               when :number
                 if p_config[:multiple]
-                  result = result.split(',').map(&:strip)
+                  result = result.split(",").map(&:strip)
                   new_result = result.map do |item|
                     new_item = item.to_i
                     new_item if new_item.to_s == item
@@ -150,7 +150,7 @@ module Sfn
               end
               collection.set_root(root_pack)
             rescue Errno::ENOENT
-              ui.warn 'No local SparkleFormation files detected'
+              ui.warn "No local SparkleFormation files detected"
             end
             sparkle_packs.each do |pack|
               collection.add_sparkle(pack)
@@ -185,8 +185,8 @@ module Sfn
               end
               sf.compile_time_parameter_setter do |formation|
                 f_name = formation.root_path.map(&:name).map(&:to_s)
-                pathed_name = f_name.join(' > ')
-                f_name = f_name.join('__')
+                pathed_name = f_name.join(" > ")
+                f_name = f_name.join("__")
                 if formation.root? && compile_state[f_name].nil?
                   current_state = compile_state
                 else
@@ -200,7 +200,7 @@ module Sfn
                   current_state = current_state.merge(formation.compile_state)
                 end
                 unless formation.parameters.empty?
-                  ui.info "#{ui.color('Compile time parameters:', :bold)} - template: #{ui.color(pathed_name, :green, :bold)}" unless config[:print_only]
+                  ui.info "#{ui.color("Compile time parameters:", :bold)} - template: #{ui.color(pathed_name, :green, :bold)}" unless config[:print_only]
                   formation.parameters.each do |k, v|
                     valid_keys = [
                       "#{f_name}__#{k}",
@@ -251,7 +251,7 @@ module Sfn
               template
             end
           else
-            raise ArgumentError.new 'Failed to locate template for processing!'
+            raise ArgumentError.new "Failed to locate template for processing!"
           end
         end
 
@@ -262,7 +262,7 @@ module Sfn
           ui.debug "Initial compile parameters - #{compile_state}"
           compile_state.keys.each do |cs_key|
             unless cs_key.to_s.start_with?("#{arguments.first}__")
-              named_cs_key = [arguments.first, cs_key].compact.join('__')
+              named_cs_key = [arguments.first, cs_key].compact.join("__")
               non_named = compile_state.delete(cs_key)
               if non_named && !compile_state.key?(named_cs_key)
                 ui.debug "Setting non-named compile parameter `#{cs_key}` into `#{named_cs_key}`"
@@ -282,8 +282,8 @@ module Sfn
         # Force user friendly error if nesting bucket is not set within configuration
         def validate_nesting_bucket!
           if config[:nesting_bucket].to_s.empty?
-            ui.error 'Missing required configuration value for `nesting_bucket`. Cannot generated nested templates!'
-            raise ArgumentError.new 'Required configuration value for `nesting_bucket` not provided.'
+            ui.error "Missing required configuration value for `nesting_bucket`. Cannot generated nested templates!"
+            raise ArgumentError.new "Required configuration value for `nesting_bucket` not provided."
           end
         end
 
@@ -307,13 +307,13 @@ module Sfn
               end
               file = bucket.files.build
               file.name = "#{name_args.first}_#{stack_name}.json"
-              file.content_type = 'text/json'
+              file.content_type = "text/json"
               file.body = MultiJson.dump(parameter_scrub!(stack_definition))
               file.save
               url = URI.parse(file.url)
               template_url = "#{url.scheme}://#{url.host}#{url.path}"
             end
-            resource.properties.set!('TemplateURL', template_url)
+            resource.properties.set!("TemplateURL", template_url)
           end
         end
 
@@ -331,16 +331,16 @@ module Sfn
             if current_stack && current_stack.data[:parent_stack]
               current_parameters.merge!(
                 current_stack.data[:parent_stack].template.fetch(
-                  'Resources', stack_name, 'Properties', 'Parameters', current_stack.data[:parent_stack].template.fetch(
-                    'resources', stack_name, 'properties', 'parameters', Smash.new
+                  "Resources", stack_name, "Properties", "Parameters", current_stack.data[:parent_stack].template.fetch(
+                    "resources", stack_name, "properties", "parameters", Smash.new
                   )
                 )
               )
             end
             full_stack_name = [
               config[:nesting_prefix],
-              stack.root_path.map(&:name).map(&:to_s).join('_'),
-            ].compact.join('/')
+              stack.root_path.map(&:name).map(&:to_s).join("_"),
+            ].compact.join("/")
             unless config[:print_only]
               result = Smash.new(
                 :parameters => populate_parameters!(stack,
@@ -390,7 +390,7 @@ module Sfn
           end
           file = bucket.files.build
           file.name = "#{full_stack_name}.json"
-          file.content_type = 'text/json'
+          file.content_type = "text/json"
           file.body = MultiJson.dump(parameter_scrub!(stack_definition))
           file.save
           result.merge!(
@@ -422,9 +422,9 @@ module Sfn
         # @return [Hash]
         def scrub_template(template)
           template = parameter_scrub!(template)
-          (template['Resources'] || {}).each do |r_name, r_content|
-            if valid_stack_types.include?(r_content['Type'])
-              result = (r_content['Properties'] || {}).delete('Stack')
+          (template["Resources"] || {}).each do |r_name, r_content|
+            if valid_stack_types.include?(r_content["Type"])
+              result = (r_content["Properties"] || {}).delete("Stack")
             end
           end
           template
@@ -439,11 +439,11 @@ module Sfn
           case provider
           when :aws
             if results[:parameters]
-              results['Parameters'] = results.delete(:parameters)
+              results["Parameters"] = results.delete(:parameters)
             end
             if results[:url]
               url = URI.parse(results.delete(:url))
-              results['TemplateURL'] = "#{url.scheme}://#{url.host}#{url.path}"
+              results["TemplateURL"] = "#{url.scheme}://#{url.host}#{url.path}"
             end
             results
           when :heat, :rackspace
@@ -461,10 +461,10 @@ module Sfn
             if results[:url]
               results[:templateLink] = Smash.new(
                 :uri => results.delete(:url),
-                :contentVersion => '1.0.0.0',
+                :contentVersion => "1.0.0.0",
               )
             end
-            results[:mode] = 'Incremental'
+            results[:mode] = "Incremental"
             results
           else
             raise "Unknown stack provider value given! `#{provider}`"
@@ -491,7 +491,7 @@ module Sfn
             translator = klass.new(template, args)
             translator.translate!
             template = translator.translated
-            ui.info "#{ui.color('Translation applied:', :bold)} #{ui.color(klass_name, :yellow)}"
+            ui.info "#{ui.color("Translation applied:", :bold)} #{ui.color(klass_name, :yellow)}"
           end
           template
         end
@@ -530,9 +530,9 @@ module Sfn
         # @return [String] path to template
         def prompt_for_template(prefix = nil)
           if prefix
-            collection_name = prefix.split('__').map do |c_name|
-              c_name.split('_').map(&:capitalize).join(' ')
-            end.join(' / ')
+            collection_name = prefix.split("__").map do |c_name|
+              c_name.split("_").map(&:capitalize).join(" ")
+            end.join(" / ")
             ui.info "Viewing collection: #{ui.color(collection_name, :bold)}"
             template_names = sparkle_collection.templates.fetch(provider.connection.provider, {}).keys.find_all do |t_name|
               t_name.to_s.start_with?(prefix.to_s)
@@ -541,46 +541,46 @@ module Sfn
             template_names = sparkle_collection.templates.fetch(provider.connection.provider, {}).keys
           end
           collections = template_names.map do |t_name|
-            t_name = t_name.to_s.sub(/^#{Regexp.escape(prefix.to_s)}/, '')
-            if t_name.include?('__')
-              c_name = t_name.split('__').first
-              [[prefix, c_name].compact.join('') + '__', c_name]
+            t_name = t_name.to_s.sub(/^#{Regexp.escape(prefix.to_s)}/, "")
+            if t_name.include?("__")
+              c_name = t_name.split("__").first
+              [[prefix, c_name].compact.join("") + "__", c_name]
             end
           end.compact.uniq(&:first)
           templates = template_names.map do |t_name|
-            t_name = t_name.to_s.sub(/^#{Regexp.escape(prefix.to_s)}/, '')
-            unless t_name.include?('__')
-              [[prefix, t_name].compact.join(''), t_name]
+            t_name = t_name.to_s.sub(/^#{Regexp.escape(prefix.to_s)}/, "")
+            unless t_name.include?("__")
+              [[prefix, t_name].compact.join(""), t_name]
             end
           end.compact
           if collections.empty? && templates.empty?
-            ui.error 'Failed to locate any templates!'
+            ui.error "Failed to locate any templates!"
             return nil
           end
-          ui.info "Please select an entry#{'(or collection to list)' unless collections.empty?}:"
+          ui.info "Please select an entry#{"(or collection to list)" unless collections.empty?}:"
           output = []
           idx = 1
           valid = {}
           unless collections.empty?
-            output << ui.color('Collections:', :bold)
+            output << ui.color("Collections:", :bold)
             collections.each do |full_name, part_name|
               valid[idx] = {:name => full_name, :type => :collection}
-              output << [idx, part_name.split('_').map(&:capitalize).join(' ')]
+              output << [idx, part_name.split("_").map(&:capitalize).join(" ")]
               idx += 1
             end
           end
           unless templates.empty?
-            output << ui.color('Templates:', :bold)
+            output << ui.color("Templates:", :bold)
             templates.each do |full_name, part_name|
               valid[idx] = {:name => full_name, :type => :template}
-              output << [idx, part_name.split('_').map(&:capitalize).join(' ')]
+              output << [idx, part_name.split("_").map(&:capitalize).join(" ")]
               idx += 1
             end
           end
           max = idx.to_s.length
           output.map! do |line|
             if line.is_a?(Array)
-              "  #{line.first}.#{' ' * (max - line.first.to_s.length)} #{line.last}"
+              "  #{line.first}.#{" " * (max - line.first.to_s.length)} #{line.last}"
             else
               line
             end
@@ -588,7 +588,7 @@ module Sfn
           ui.puts "#{output.join("\n")}\n"
           response = nil
           until valid[response]
-            response = ui.ask_question('Enter selection').to_i
+            response = ui.ask_question("Enter selection").to_i
           end
           entry = valid[response]
           if entry[:type] == :collection

--- a/lib/sfn/config.rb
+++ b/lib/sfn/config.rb
@@ -1,5 +1,5 @@
-require 'sfn'
-require 'bogo-config'
+require "sfn"
+require "bogo-config"
 
 module Sfn
 
@@ -30,8 +30,8 @@ module Sfn
               v
             end
           end
-          info[:description] ||= ''
-          info[:description] << ' (Key:Value[,Key:Value,...])'
+          info[:description] ||= ""
+          info[:description] << " (Key:Value[,Key:Value,...])"
         end
       end
       super(name, type, info)
@@ -40,72 +40,72 @@ module Sfn
     # Only values allowed designating bool type
     BOOLEAN_VALUES = [TrueClass, FalseClass]
 
-    autoload :Conf, 'sfn/config/conf'
-    autoload :Create, 'sfn/config/create'
-    autoload :Describe, 'sfn/config/describe'
-    autoload :Destroy, 'sfn/config/destroy'
-    autoload :Describe, 'sfn/config/describe'
-    autoload :Diff, 'sfn/config/diff'
-    autoload :Events, 'sfn/config/events'
-    autoload :Export, 'sfn/config/export'
-    autoload :Graph, 'sfn/config/graph'
-    autoload :Import, 'sfn/config/import'
-    autoload :Init, 'sfn/config/init'
-    autoload :Inspect, 'sfn/config/inspect'
-    autoload :Lint, 'sfn/config/lint'
-    autoload :List, 'sfn/config/list'
-    autoload :Print, 'sfn/config/print'
-    autoload :Promote, 'sfn/config/promote'
-    autoload :Update, 'sfn/config/update'
-    autoload :Validate, 'sfn/config/validate'
+    autoload :Conf, "sfn/config/conf"
+    autoload :Create, "sfn/config/create"
+    autoload :Describe, "sfn/config/describe"
+    autoload :Destroy, "sfn/config/destroy"
+    autoload :Describe, "sfn/config/describe"
+    autoload :Diff, "sfn/config/diff"
+    autoload :Events, "sfn/config/events"
+    autoload :Export, "sfn/config/export"
+    autoload :Graph, "sfn/config/graph"
+    autoload :Import, "sfn/config/import"
+    autoload :Init, "sfn/config/init"
+    autoload :Inspect, "sfn/config/inspect"
+    autoload :Lint, "sfn/config/lint"
+    autoload :List, "sfn/config/list"
+    autoload :Print, "sfn/config/print"
+    autoload :Promote, "sfn/config/promote"
+    autoload :Update, "sfn/config/update"
+    autoload :Validate, "sfn/config/validate"
 
     attribute(
       :config, String,
-      :description => 'Configuration file path',
-      :short_flag => 'c',
+      :description => "Configuration file path",
+      :short_flag => "c",
     )
 
     attribute(
       :credentials, Smash,
-      :description => 'Provider credentials',
-      :short_flag => 'C',
+      :description => "Provider credentials",
+      :short_flag => "C",
     )
     attribute(
       :ignore_parameters, String,
       :multiple => true,
-      :description => 'Parameters to ignore during modifications',
-      :short_flag => 'i',
+      :description => "Parameters to ignore during modifications",
+      :short_flag => "i",
     )
     attribute(
       :interactive_parameters, [TrueClass, FalseClass],
       :default => true,
-      :description => 'Prompt for template parameters',
-      :short_flag => 'I',
+      :description => "Prompt for template parameters",
+      :short_flag => "I",
     )
     attribute(
       :poll, [TrueClass, FalseClass],
       :default => true,
-      :description => 'Poll stack events on modification actions',
-      :short_flag => 'p',
+      :description => "Poll stack events on modification actions",
+      :short_flag => "p",
     )
     attribute(
       :defaults, [TrueClass, FalseClass],
-      :description => 'Automatically accept default values',
-      :short_flag => 'd',
+      :description => "Automatically accept default values",
+      :short_flag => "d",
     )
     attribute(
       :yes, [TrueClass, FalseClass],
-      :description => 'Automatically accept any requests for confirmation',
-      :short_flag => 'y',
+      :description => "Automatically accept any requests for confirmation",
+      :short_flag => "y",
     )
     attribute(
       :debug, [TrueClass, FalseClass],
-      :description => 'Enable debug output',
-      :short_flag => 'u',
+      :description => "Enable debug output",
+      :short_flag => "u",
     )
     attribute(
       :colors, [TrueClass, FalseClass],
-      :description => 'Enable colorized output',
+      :description => "Enable colorized output",
       :default => true,
     )
 
@@ -127,7 +127,7 @@ module Sfn
     # @param klass [Class]
     # @return [Smash]
     def self.options_for(klass)
-      shorts = ['h'] # always reserve `-h` for help
+      shorts = ["h"] # always reserve `-h` for help
       _options_for(klass, shorts)
     end
 
@@ -152,7 +152,7 @@ module Sfn
             shorts << short
             info[:short] = short
           end
-          info[:long] = name.tr('_', '-')
+          info[:long] = name.tr("_", "-")
           info[:boolean] = [info[:type]].compact.flatten.all? { |t| BOOLEAN_VALUES.include?(t) }
           [name, info]
         end.compact

--- a/lib/sfn/config/conf.rb
+++ b/lib/sfn/config/conf.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -6,8 +6,8 @@ module Sfn
     class Conf < Create
       attribute(
         :generate, [TrueClass, FalseClass],
-        :description => 'Generate a basic configuration file',
-        :short_flag => 'g',
+        :description => "Generate a basic configuration file",
+        :short_flag => "g",
       )
     end
   end

--- a/lib/sfn/config/create.rb
+++ b/lib/sfn/config/create.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -7,24 +7,24 @@ module Sfn
       attribute(
         :timeout, Integer,
         :coerce => proc { |v| v.to_i },
-        :description => 'Seconds to wait for stack to complete',
-        :short_flag => 'M',
+        :description => "Seconds to wait for stack to complete",
+        :short_flag => "M",
       )
       attribute(
         :rollback, [TrueClass, FalseClass],
-        :description => 'Rollback stack on failure',
-        :short_flag => 'O',
+        :description => "Rollback stack on failure",
+        :short_flag => "O",
       )
       attribute(
         :options, Smash,
-        :description => 'Extra options to apply to the API call',
-        :short_flag => 'S',
+        :description => "Extra options to apply to the API call",
+        :short_flag => "S",
       )
       attribute(
         :notification_topics, String,
         :multiple => true,
-        :description => 'Notification endpoints for stack events',
-        :short_flag => 'z',
+        :description => "Notification endpoints for stack events",
+        :short_flag => "z",
       )
     end
   end

--- a/lib/sfn/config/describe.rb
+++ b/lib/sfn/config/describe.rb
@@ -1,24 +1,24 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
     class Describe < Config
       attribute(
         :resources, [TrueClass, FalseClass],
-        :description => 'Display stack resource list',
-        :short_flag => 'r',
+        :description => "Display stack resource list",
+        :short_flag => "r",
       )
 
       attribute(
         :outputs, [TrueClass, FalseClass],
-        :description => 'Display stack outputs',
-        :short_flag => 'o',
+        :description => "Display stack outputs",
+        :short_flag => "o",
       )
 
       attribute(
         :tags, [TrueClass, FalseClass],
-        :description => 'Display stack tags',
-        :short_flag => 't',
+        :description => "Display stack tags",
+        :short_flag => "t",
       )
     end
   end

--- a/lib/sfn/config/destroy.rb
+++ b/lib/sfn/config/destroy.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config

--- a/lib/sfn/config/diff.rb
+++ b/lib/sfn/config/diff.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -7,8 +7,8 @@ module Sfn
       attribute(
         :raw_diff, [TrueClass, FalseClass],
         :default => false,
-        :description => 'Display raw diff information',
-        :short_flag => 'w',
+        :description => "Display raw diff information",
+        :short_flag => "w",
       )
     end
   end

--- a/lib/sfn/config/events.rb
+++ b/lib/sfn/config/events.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -7,25 +7,25 @@ module Sfn
       attribute(
         :attribute, String,
         :multiple => true,
-        :description => 'Event attribute to display',
-        :short_flag => 'a',
+        :description => "Event attribute to display",
+        :short_flag => "a",
       )
       attribute(
         :poll_delay, Integer,
         :default => 20,
-        :description => 'Seconds to pause between each event poll',
+        :description => "Seconds to pause between each event poll",
         :coerce => lambda { |v| v.to_i },
-        :short_flag => 'P',
+        :short_flag => "P",
       )
       attribute(
         :all_attributes, [TrueClass, FalseClass],
-        :description => 'Display all event attributes',
-        :short_flag => 'A',
+        :description => "Display all event attributes",
+        :short_flag => "A",
       )
       attribute(
         :all_events, [TrueClass, FalseClass],
-        :description => 'Display all available events',
-        :short_flag => 'L',
+        :description => "Display all available events",
+        :short_flag => "L",
       )
     end
   end

--- a/lib/sfn/config/export.rb
+++ b/lib/sfn/config/export.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -7,19 +7,19 @@ module Sfn
     class Export < Config
       attribute(
         :name, String,
-        :description => 'Export file base name',
+        :description => "Export file base name",
       )
       attribute(
         :path, String,
-        :description => 'Local path prefix for dump file',
+        :description => "Local path prefix for dump file",
       )
       attribute(
         :bucket, String,
-        :description => 'Remote storage bucket',
+        :description => "Remote storage bucket",
       )
       attribute(
         :bucket_prefix, String,
-        :description => 'Remote key prefix within bucket for dump file',
+        :description => "Remote key prefix within bucket for dump file",
       )
     end
   end

--- a/lib/sfn/config/graph.rb
+++ b/lib/sfn/config/graph.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -6,27 +6,27 @@ module Sfn
     class Graph < Validate
       attribute(
         :output_file, String,
-        :description => 'Directory to write graph files',
-        :short_flag => 'O',
-        :default => File.join(Dir.pwd, 'sfn-graph'),
+        :description => "Directory to write graph files",
+        :short_flag => "O",
+        :default => File.join(Dir.pwd, "sfn-graph"),
       )
 
       attribute(
         :output_type, String,
-        :description => 'File output type (Requires graphviz package for non-dot types)',
-        :short_flag => 'e',
-        :default => 'dot',
+        :description => "File output type (Requires graphviz package for non-dot types)",
+        :short_flag => "e",
+        :default => "dot",
       )
 
       attribute(
         :graph_style, String,
-        :description => 'Style of graph (`dependency`, `creation`)',
-        :default => 'creation',
+        :description => "Style of graph (`dependency`, `creation`)",
+        :default => "creation",
       )
 
       attribute(
         :luckymike, [TrueClass, FalseClass],
-        :description => 'Force `dependency` style graph',
+        :description => "Force `dependency` style graph",
         :default => false,
       )
     end

--- a/lib/sfn/config/import.rb
+++ b/lib/sfn/config/import.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -7,15 +7,15 @@ module Sfn
     class Import < Config
       attribute(
         :path, String,
-        :description => 'Directory path JSON export files are located',
+        :description => "Directory path JSON export files are located",
       )
       attribute(
         :bucket, String,
-        :description => 'Remote storage bucket JSON export files are located',
+        :description => "Remote storage bucket JSON export files are located",
       )
       attribute(
         :bucket_prefix, String,
-        :description => 'Remote key prefix within bucket for dump file',
+        :description => "Remote key prefix within bucket for dump file",
       )
     end
   end

--- a/lib/sfn/config/init.rb
+++ b/lib/sfn/config/init.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config

--- a/lib/sfn/config/inspect.rb
+++ b/lib/sfn/config/inspect.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -7,39 +7,39 @@ module Sfn
       attribute(
         :attribute, String,
         :multiple => true,
-        :description => 'Dot delimited attribute to view',
-        :short_flag => 'a',
+        :description => "Dot delimited attribute to view",
+        :short_flag => "a",
       )
       attribute(
         :nodes, [TrueClass, FalseClass],
-        :description => 'Locate all instances and display addresses',
-        :short_flag => 'n',
+        :description => "Locate all instances and display addresses",
+        :short_flag => "n",
       )
       attribute(
         :load_balancers, [TrueClass, FalseClass],
-        :description => 'Locate all load balancers, display addresses and server states',
-        :short_flag => 'l',
+        :description => "Locate all load balancers, display addresses and server states",
+        :short_flag => "l",
       )
       attribute(
         :instance_failure, [TrueClass, FalseClass],
-        :description => 'Display log file error from failed not if possible',
-        :short_flag => 'N',
+        :description => "Display log file error from failed not if possible",
+        :short_flag => "N",
       )
       attribute(
         :failure_log_path, String,
-        :description => 'Path to remote log file for display on failure',
-        :default => '/var/log/chef/client.log',
-        :short_flag => 'f',
+        :description => "Path to remote log file for display on failure",
+        :default => "/var/log/chef/client.log",
+        :short_flag => "f",
       )
       attribute(
         :identity_file, String,
-        :description => 'SSH identity file for authentication',
-        :short_flag => 'D',
+        :description => "SSH identity file for authentication",
+        :short_flag => "D",
       )
       attribute(
         :ssh_user, String,
-        :description => 'SSH username for inspection connect',
-        :short_flag => 's',
+        :description => "SSH username for inspection connect",
+        :short_flag => "s",
       )
     end
   end

--- a/lib/sfn/config/lint.rb
+++ b/lib/sfn/config/lint.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -6,22 +6,22 @@ module Sfn
     class Lint < Validate
       attribute(
         :lint_directory, String,
-        :description => 'Directory containing lint rule sets',
+        :description => "Directory containing lint rule sets",
         :multiple => true,
       )
       attribute(
         :disabled_rule_set, String,
-        :description => 'Disable rule set from being applied',
+        :description => "Disable rule set from being applied",
         :multiple => true,
       )
       attribute(
         :enabled_rule_set, String,
-        :description => 'Only apply this rule set',
+        :description => "Only apply this rule set",
         :multiple => true,
       )
       attribute(
         :local_rule_sets_only, [TrueClass, FalseClass],
-        :description => 'Only apply rule sets provided by lint directory',
+        :description => "Only apply rule sets provided by lint directory",
         :default => false,
       )
     end

--- a/lib/sfn/config/list.rb
+++ b/lib/sfn/config/list.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -7,19 +7,19 @@ module Sfn
       attribute(
         :attribute, String,
         :multiple => true,
-        :description => 'Attribute of stack to print',
-        :short_flag => 'a',
+        :description => "Attribute of stack to print",
+        :short_flag => "a",
       )
       attribute(
         :all_attributes, [TrueClass, FalseClass],
-        :description => 'Print all available attributes',
-        :short_flag => 'A',
+        :description => "Print all available attributes",
+        :short_flag => "A",
       )
       attribute(
         :status, String,
         :multiple => true,
         :description => 'Match stacks with given status. Use "none" to disable.',
-        :short_flag => 's',
+        :short_flag => "s",
       )
     end
   end

--- a/lib/sfn/config/print.rb
+++ b/lib/sfn/config/print.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -6,18 +6,18 @@ module Sfn
     class Print < Validate
       attribute(
         :write_to_file, String,
-        :description => 'Write compiled SparkleFormation template to path provided',
-        :short_flag => 'w',
+        :description => "Write compiled SparkleFormation template to path provided",
+        :short_flag => "w",
       )
 
       attribute(
         :sparkle_dump, [TrueClass, FalseClass],
-        :description => 'Do not use provider customized dump behavior',
+        :description => "Do not use provider customized dump behavior",
       )
 
       attribute(
         :yaml, [TrueClass, FalseClass],
-        :description => 'Output template content in YAML format',
+        :description => "Output template content in YAML format",
       )
     end
   end

--- a/lib/sfn/config/promote.rb
+++ b/lib/sfn/config/promote.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -6,15 +6,15 @@ module Sfn
     class Promote < Config
       attribute(
         :accounts, String,
-        :description => 'JSON accounts file path',
+        :description => "JSON accounts file path",
       )
       attribute(
         :bucket, String,
-        :description => 'Bucket name containing the exports',
+        :description => "Bucket name containing the exports",
       )
       attribute(
         :bucket_prefix, String,
-        :description => 'Key prefix within remote bucket',
+        :description => "Key prefix within remote bucket",
       )
     end
   end

--- a/lib/sfn/config/update.rb
+++ b/lib/sfn/config/update.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -7,22 +7,22 @@ module Sfn
       attribute(
         :apply_stack, String,
         :multiple => true,
-        :description => 'Apply outputs from stack to input parameters',
-        :short_flag => 'A',
+        :description => "Apply outputs from stack to input parameters",
+        :short_flag => "A",
       )
       attribute(
         :apply_mapping, Smash,
-        :description => 'Customize apply stack mapping as [StackName__]OutputName:ParameterName',
+        :description => "Customize apply stack mapping as [StackName__]OutputName:ParameterName",
       )
       attribute(
         :parameter, Smash,
         :multiple => true,
-        :description => '[DEPRECATED - use `parameters`] Pass template parameters directly (ParamName:ParamValue)',
+        :description => "[DEPRECATED - use `parameters`] Pass template parameters directly (ParamName:ParamValue)",
         :coerce => lambda { |v, inst|
           result = inst.data[:parameter] || Array.new
           case v
           when String
-            v.split(',').each do |item|
+            v.split(",").each do |item|
               result.push(Smash[*item.split(/[=:]/, 2)])
             end
           else
@@ -30,39 +30,39 @@ module Sfn
           end
           {:bogo_multiple => result}
         },
-        :short_flag => 'R',
+        :short_flag => "R",
       )
       attribute(
         :parameters, Smash,
-        :description => 'Pass template parameters directly',
-        :short_flag => 'm',
+        :description => "Pass template parameters directly",
+        :short_flag => "m",
       )
       attribute(
         :plan, [TrueClass, FalseClass],
         :default => true,
-        :description => 'Provide planning information prior to update',
-        :short_flag => 'l',
+        :description => "Provide planning information prior to update",
+        :short_flag => "l",
       )
       attribute(
         :plan_only, [TrueClass, FalseClass],
         :default => false,
-        :description => 'Exit after plan display',
+        :description => "Exit after plan display",
       )
       attribute(
         :diffs, [TrueClass, FalseClass],
-        :description => 'Show planner content diff',
-        :short_flag => 'D',
+        :description => "Show planner content diff",
+        :short_flag => "D",
       )
       attribute(
         :merge_api_options, [TrueClass, FalseClass],
-        :description => 'Merge API options defined within configuration on update',
+        :description => "Merge API options defined within configuration on update",
         :default => false,
       )
       attribute(
         :parameter_validation, String,
-        :allowed => ['default', 'none', 'current', 'expected'],
-        :description => 'Stack parameter validation behavior',
-        :default => 'default',
+        :allowed => ["default", "none", "current", "expected"],
+        :description => "Stack parameter validation behavior",
+        :default => "default",
       )
     end
   end

--- a/lib/sfn/config/validate.rb
+++ b/lib/sfn/config/validate.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   class Config
@@ -6,80 +6,80 @@ module Sfn
     class Validate < Config
       attribute(
         :processing, [TrueClass, FalseClass],
-        :description => 'Call the unicorns and explode the glitter bombs',
+        :description => "Call the unicorns and explode the glitter bombs",
         :default => true,
-        :short_flag => 'P',
+        :short_flag => "P",
       )
       attribute(
         :file, String,
-        :description => 'Path to template file',
+        :description => "Path to template file",
         :default => nil,
-        :short_flag => 'f',
+        :short_flag => "f",
       )
       attribute(
         :file_path_prompt, [TrueClass, FalseClass],
         :default => true,
-        :description => 'Enable interactive prompt for template path discovery',
-        :short_flag => 'F',
+        :description => "Enable interactive prompt for template path discovery",
+        :short_flag => "F",
       )
       attribute(
         :base_directory, String,
-        :description => 'Path to root of of templates directory',
-        :short_flag => 'b',
+        :description => "Path to root of of templates directory",
+        :short_flag => "b",
       )
       attribute(
         :no_base_directory, [TrueClass, FalseClass],
-        :description => 'Unset any value used for the template root directory path',
-        :short_flag => 'n',
+        :description => "Unset any value used for the template root directory path",
+        :short_flag => "n",
       )
       attribute(
         :translate, String,
-        :description => 'Translate generated template to given provider',
-        :short_flag => 't',
+        :description => "Translate generated template to given provider",
+        :short_flag => "t",
       )
       attribute(
         :translate_chunk, Integer,
-        :description => 'Chunk length for serialization',
+        :description => "Chunk length for serialization",
         :coerce => lambda { |v| v.to_i },
-        :short_flag => 'T',
+        :short_flag => "T",
       )
       attribute(
         :apply_nesting, [String, Symbol],
-        :default => 'deep',
-        :description => 'Apply stack nesting',
-        :short_flag => 'a',
+        :default => "deep",
+        :description => "Apply stack nesting",
+        :short_flag => "a",
       )
       attribute(
         :nesting_bucket, String,
-        :description => 'Bucket to use for storing nested stack templates',
-        :short_flag => 'N',
+        :description => "Bucket to use for storing nested stack templates",
+        :short_flag => "N",
       )
       attribute(
         :nesting_prefix, String,
-        :description => 'File name prefix for storing template in bucket',
-        :short_flag => 'Y',
+        :description => "File name prefix for storing template in bucket",
+        :short_flag => "Y",
       )
       attribute(
         :print_only, [TrueClass, FalseClass],
-        :description => 'Print the resulting stack template',
-        :short_flag => 'r',
+        :description => "Print the resulting stack template",
+        :short_flag => "r",
       )
       attribute(
         :sparkle_pack, String,
         :multiple => true,
-        :description => 'Load SparklePack gem',
+        :description => "Load SparklePack gem",
         :coerce => lambda { |s| s.to_s },
-        :short_flag => 's',
+        :short_flag => "s",
       )
       attribute(
         :compile_parameters, Smash,
-        :description => 'Pass template compile time parameters directly',
-        :short_flag => 'o',
+        :description => "Pass template compile time parameters directly",
+        :short_flag => "o",
         :coerce => lambda { |v|
           case v
           when String
             result = Smash.new
-            v.split(',').each do |item_pair|
+            v.split(",").each do |item_pair|
               key, value = item_pair.split(/[=:]/, 2)
               result[key] = value
             end
@@ -104,7 +104,7 @@ module Sfn
       )
       attribute(
         :upload_root_template, [TrueClass, FalseClass],
-        :description => 'Upload root template to storage bucket',
+        :description => "Upload root template to storage bucket",
       )
     end
   end

--- a/lib/sfn/lint.rb
+++ b/lib/sfn/lint.rb
@@ -1,10 +1,10 @@
-require 'sfn'
-require 'jmespath'
+require "sfn"
+require "jmespath"
 
 module Sfn
   module Lint
-    autoload :Definition, 'sfn/lint/definition'
-    autoload :Rule, 'sfn/lint/rule'
-    autoload :RuleSet, 'sfn/lint/rule_set'
+    autoload :Definition, "sfn/lint/definition"
+    autoload :Rule, "sfn/lint/rule"
+    autoload :RuleSet, "sfn/lint/rule_set"
   end
 end

--- a/lib/sfn/lint/definition.rb
+++ b/lib/sfn/lint/definition.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Lint
@@ -20,7 +20,7 @@ module Sfn
       # @return [self]
       def initialize(expr, provider = :aws, evaluator = nil, &block)
         if evaluator && block
-          raise ArgumentError.new 'Only evaluator or block can be provided, not both.'
+          raise ArgumentError.new "Only evaluator or block can be provided, not both."
         end
         @provider = Bogo::Utility.snake(provider).to_sym
         @search_expression = expr
@@ -46,7 +46,7 @@ module Sfn
       # @note override this method when subclassing
       def run(result, template)
         unless evaluator
-          raise NotImplementedError.new 'No evaluator has been defined for this definition!'
+          raise NotImplementedError.new "No evaluator has been defined for this definition!"
         end
         evaluator.call(result, template)
       end

--- a/lib/sfn/lint/rule.rb
+++ b/lib/sfn/lint/rule.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Lint
@@ -40,7 +40,7 @@ module Sfn
             f_item
           end.flatten.compact.map(&:to_s)
           unless failed_items.empty?
-            msg = "#{msg} (failures: `#{failed_items.join('`, `')}`)"
+            msg = "#{msg} (failures: `#{failed_items.join("`, `")}`)"
           end
         end
         msg
@@ -109,7 +109,7 @@ module Sfn
         end
         unless non_match.empty?
           raise ArgumentError.new "Rule defines `#{provider}` as provider but includes definitions for " \
-                                  "non matching providers. (#{non_match.map(&:provider).map(&:to_s).uniq.sort.join(', ')})"
+                                  "non matching providers. (#{non_match.map(&:provider).map(&:to_s).uniq.sort.join(", ")})"
         end
       end
     end

--- a/lib/sfn/lint/rule_set.rb
+++ b/lib/sfn/lint/rule_set.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Lint
@@ -160,7 +160,7 @@ module Sfn
         end
         unless non_match.empty?
           raise ArgumentError.new "Rule set defines `#{provider}` as provider but includes rules for " \
-                                  "non matching providers. (#{non_match.map(&:provider).map(&:to_s).uniq.sort.join(', ')})"
+                                  "non matching providers. (#{non_match.map(&:provider).map(&:to_s).uniq.sort.join(", ")})"
         end
       end
     end

--- a/lib/sfn/monkey_patch.rb
+++ b/lib/sfn/monkey_patch.rb
@@ -1,8 +1,8 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   # Container for monkey patches
   module MonkeyPatch
-    autoload :Stack, 'sfn/monkey_patch/stack'
+    autoload :Stack, "sfn/monkey_patch/stack"
   end
 end

--- a/lib/sfn/monkey_patch/stack/azure.rb
+++ b/lib/sfn/monkey_patch/stack/azure.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module MonkeyPatch

--- a/lib/sfn/monkey_patch/stack/google.rb
+++ b/lib/sfn/monkey_patch/stack/google.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module MonkeyPatch
@@ -50,7 +50,7 @@ module Sfn
             my_template = my_template.get(:resources, name, :properties, :stack)
           end
           n_stacks = my_template[:resources].map do |s_name, content|
-            if content[:type] == 'sparkleformation.stack'
+            if content[:type] == "sparkleformation.stack"
               n_stack = self.class.new(api)
               n_stack.extend PretendStack
               n_layout = custom.fetch(:layout, {}).fetch(:resources, []).detect { |r| r[:name] == name }
@@ -59,7 +59,7 @@ module Sfn
                 :name => s_name,
                 :id => s_name,
                 :template => content.get(:properties, :stack),
-                :outputs => n_layout.fetch('outputs', []).map { |o_val| Smash.new(:key => o_val[:name], :value => o_val['finalValue']) },
+                :outputs => n_layout.fetch("outputs", []).map { |o_val| Smash.new(:key => o_val[:name], :value => o_val["finalValue"]) },
                 :custom => {
                   :resources => resources.all.map(&:attributes),
                   :layout => n_layout,
@@ -84,7 +84,7 @@ module Sfn
             result = template.to_smash
             (result.delete(:resources) || []).each do |t_resource|
               t_name = t_resource.delete(:name)
-              if t_resource[:type].to_s.end_with?('.jinja')
+              if t_resource[:type].to_s.end_with?(".jinja")
                 schema = copy_template.fetch(:config, :content, :imports, []).delete("#{t_resource[:type]}.schema")
                 schema_content = copy_template.fetch(:imports, []).detect do |s_item|
                   s_item[:name] == schema
@@ -96,7 +96,7 @@ module Sfn
                   s_item[:name] == t_resource[:type]
                 end
                 if n_template
-                  t_resource[:type] = 'sparkleformation.stack'
+                  t_resource[:type] = "sparkleformation.stack"
                   current_properties = t_resource.delete(:properties)
                   t_resource.set(:properties, :parameters, current_properties) if current_properties
                   t_resource.set(:properties, :stack, deref.call(n_template[:content]))

--- a/lib/sfn/planner.rb
+++ b/lib/sfn/planner.rb
@@ -1,12 +1,12 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   # Interface for generating plan report
   class Planner
-    autoload :Aws, 'sfn/planner/aws'
+    autoload :Aws, "sfn/planner/aws"
 
     # Value to flag runtime modification
-    RUNTIME_MODIFIED = '__MODIFIED_REFERENCE_VALUE__'
+    RUNTIME_MODIFIED = "__MODIFIED_REFERENCE_VALUE__"
 
     # @return [Bogo::Ui]
     attr_reader :ui

--- a/lib/sfn/provider.rb
+++ b/lib/sfn/provider.rb
@@ -1,5 +1,5 @@
-require 'logger'
-require 'sfn'
+require "logger"
+require "sfn"
 
 module Sfn
   # Remote provider interface
@@ -41,14 +41,14 @@ module Sfn
       args = args.to_smash
       unless args.get(:miasma, :provider)
         best_guess = (args[:miasma] || {}).keys.group_by do |key|
-          key.to_s.split('_').first
+          key.to_s.split("_").first
         end.sort do |x, y|
           y.size <=> x.size
         end.first
         if best_guess
           provider = best_guess.first.to_sym
         else
-          raise ArgumentError.new 'Cannot auto determine :provider value for credentials'
+          raise ArgumentError.new "Cannot auto determine :provider value for credentials"
         end
       else
         provider = args[:miasma].delete(:provider).to_sym
@@ -58,13 +58,13 @@ module Sfn
           args[:miasma][:aws_region] = args[:miasma].delete(:region)
         end
       end
-      if ENV['DEBUG'].to_s.downcase == 'true'
+      if ENV["DEBUG"].to_s.downcase == "true"
         log_to = STDOUT
       else
         if Gem.win_platform?
-          log_to = 'NUL'
+          log_to = "NUL"
         else
-          log_to = '/dev/null'
+          log_to = "/dev/null"
         end
       end
       @logger = args.fetch(:logger, Logger.new(log_to))
@@ -101,7 +101,7 @@ module Sfn
         fetch_stacks(stack_id) if recache
       end
       value = cache[:stacks].value
-      value ? MultiJson.dump(MultiJson.load(value).values) : '[]'
+      value ? MultiJson.dump(MultiJson.load(value).values) : "[]"
     end
 
     # @return [Miasma::Orchestration::Stack, NilClass]
@@ -118,7 +118,7 @@ module Sfn
       current_stacks = MultiJson.load(cached_stacks)
       cache.locked_action(:stacks_lock) do
         logger.info "Saving expanded stack attributes in cache (#{stack_id})"
-        current_stacks[stack_id] = stack_attributes.merge('Cached' => Time.now.to_i)
+        current_stacks[stack_id] = stack_attributes.merge("Cached" => Time.now.to_i)
         cache[:stacks].value = MultiJson.dump(current_stacks)
       end
       true
@@ -144,14 +144,14 @@ module Sfn
     # @param stack [Miasma::Models::Orchestration::Stack]
     def expand_stack(stack)
       logger.info "Stack expansion requested (#{stack.id})"
-      if ((stack.in_progress? && Time.now.to_i - stack.attributes['Cached'].to_i > stack_expansion_interval) ||
-          !stack.attributes['Cached'])
+      if ((stack.in_progress? && Time.now.to_i - stack.attributes["Cached"].to_i > stack_expansion_interval) ||
+          !stack.attributes["Cached"])
         begin
           expanded = false
           cache.locked_action(:stack_expansion_lock) do
             expanded = true
             stack.reload
-            stack.data['Cached'] = Time.now.to_i
+            stack.data["Cached"] = Time.now.to_i
           end
           if expanded
             save_expanded_stack(stack.id, stack.to_json)
@@ -196,7 +196,7 @@ module Sfn
           end
         end
         cache[:stacks].value = stacks.to_json
-        logger.info 'Stack list has been updated from upstream and cached locally'
+        logger.info "Stack list has been updated from upstream and cached locally"
       end
       @initial_fetch_complete = true
     end

--- a/lib/sfn/utils.rb
+++ b/lib/sfn/utils.rb
@@ -1,17 +1,17 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   # Utility classes and modules
   module Utils
-    autoload :Output, 'sfn/utils/output'
-    autoload :StackParameterValidator, 'sfn/utils/stack_parameter_validator'
-    autoload :StackParameterScrubber, 'sfn/utils/stack_parameter_scrubber'
-    autoload :StackExporter, 'sfn/utils/stack_exporter'
-    autoload :Debug, 'sfn/utils/debug'
-    autoload :JSON, 'sfn/utils/json'
-    autoload :Ssher, 'sfn/utils/ssher'
-    autoload :ObjectStorage, 'sfn/utils/object_storage'
-    autoload :PathSelector, 'sfn/utils/path_selector'
+    autoload :Output, "sfn/utils/output"
+    autoload :StackParameterValidator, "sfn/utils/stack_parameter_validator"
+    autoload :StackParameterScrubber, "sfn/utils/stack_parameter_scrubber"
+    autoload :StackExporter, "sfn/utils/stack_exporter"
+    autoload :Debug, "sfn/utils/debug"
+    autoload :JSON, "sfn/utils/json"
+    autoload :Ssher, "sfn/utils/ssher"
+    autoload :ObjectStorage, "sfn/utils/object_storage"
+    autoload :PathSelector, "sfn/utils/path_selector"
 
     # Provide methods directly from module for previous version compatibility
     extend JSON

--- a/lib/sfn/utils/debug.rb
+++ b/lib/sfn/utils/debug.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Utils
@@ -10,7 +10,7 @@ module Sfn
         #
         # @param msg [String]
         def debug(msg)
-          if ENV['DEBUG'] || (respond_to?(:config) && config[:debug])
+          if ENV["DEBUG"] || (respond_to?(:config) && config[:debug])
             puts "<sfn - debug>: #{msg}"
           end
         end

--- a/lib/sfn/utils/json.rb
+++ b/lib/sfn/utils/json.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Utils

--- a/lib/sfn/utils/object_storage.rb
+++ b/lib/sfn/utils/object_storage.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Utils
@@ -13,13 +13,13 @@ module Sfn
       # @param directory [Miasma::Models::Storage::Directory]
       # @return [String] file path
       def file_store(object, path, directory)
-        raise NotImplementedError.new 'Internal updated required! :('
+        raise NotImplementedError.new "Internal updated required! :("
         content = object.is_a?(String) ? object : Utils._format_json(object)
         directory.files.create(
           :identity => path,
           :body => content,
         )
-        loc = directory.service.service.name.split('::').last.downcase
+        loc = directory.service.service.name.split("::").last.downcase
         "#{loc}://#{directory.identity}/#{path}"
       end
     end

--- a/lib/sfn/utils/output.rb
+++ b/lib/sfn/utils/output.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Utils
@@ -15,8 +15,8 @@ module Sfn
       def process(things, args = {})
         @event_ids ||= []
         processed = things.reverse.map do |thing|
-          next if @event_ids.include?(thing['id'])
-          @event_ids.push(thing['id']).compact!
+          next if @event_ids.include?(thing["id"])
+          @event_ids.push(thing["id"]).compact!
           if args[:attributes]
             args[:attributes].map do |key|
               thing[key].to_s
@@ -67,7 +67,7 @@ module Sfn
         output += process(things, :flat => true, :attributes => allowed_attributes)
         output.compact!
         if output.empty?
-          ui.warn 'No information found' unless args.include?(:ignore_empty_output)
+          ui.warn "No information found" unless args.include?(:ignore_empty_output)
         else
           ui.info "#{what.to_s.capitalize} for stack: #{ui.color(stack, :bold)}" if stack
           ui.info "#{ui.list(output, :uneven_columns_across, columns)}"

--- a/lib/sfn/utils/path_selector.rb
+++ b/lib/sfn/utils/path_selector.rb
@@ -1,5 +1,5 @@
-require 'sfn'
-require 'pathname'
+require "sfn"
+require "pathname"
 
 module Sfn
   module Utils
@@ -13,8 +13,8 @@ module Sfn
       # @return [String]
       def humanize_path_basename(path)
         File.basename(path).sub(
-          File.extname(path), ''
-        ).split(/[-_]/).map(&:capitalize).join(' ')
+          File.extname(path), ""
+        ).split(/[-_]/).map(&:capitalize).join(" ")
       end
 
       # Prompt user for file selection
@@ -27,7 +27,7 @@ module Sfn
       # @option opts [String] :filter_prefix only return results matching filter
       # @return [String] file path
       def prompt_for_file(directory, opts = {})
-        file_list = Dir.glob(File.join(directory, '**', '**', '*')).find_all do |file|
+        file_list = Dir.glob(File.join(directory, "**", "**", "*")).find_all do |file|
           File.file?(file)
         end
         if opts[:filter_prefix]
@@ -39,7 +39,7 @@ module Sfn
           File.dirname(file)
         end.uniq
         files = file_list.find_all do |path|
-          path.sub(directory, '').split('/').size == 2
+          path.sub(directory, "").split("/").size == 2
         end
         if opts[:ignore_directories]
           directories.delete_if do |dir|
@@ -47,16 +47,16 @@ module Sfn
           end
         end
         if directories.empty? && files.empty?
-          ui.fatal 'No formation paths discoverable!'
+          ui.fatal "No formation paths discoverable!"
         else
-          output = ['Please select an entry']
-          output << '(or directory to list):' unless directories.empty?
-          ui.info output.join(' ')
+          output = ["Please select an entry"]
+          output << "(or directory to list):" unless directories.empty?
+          ui.info output.join(" ")
           output.clear
           idx = 1
           valid = {}
           unless directories.empty?
-            output << ui.color("#{opts.fetch(:directories_name, 'Directories')}:", :bold)
+            output << ui.color("#{opts.fetch(:directories_name, "Directories")}:", :bold)
             directories.each do |dir|
               valid[idx] = {:path => dir, :type => :directory}
               output << [idx, humanize_path_basename(dir)]
@@ -64,7 +64,7 @@ module Sfn
             end
           end
           unless files.empty?
-            output << ui.color("#{opts.fetch(:files_name, 'Files')}:", :bold)
+            output << ui.color("#{opts.fetch(:files_name, "Files")}:", :bold)
             files.each do |file|
               valid[idx] = {:path => file, :type => :file}
               output << [idx, humanize_path_basename(file)]
@@ -74,15 +74,15 @@ module Sfn
           max = idx.to_s.length
           output.map! do |o|
             if o.is_a?(Array)
-              "  #{o.first}.#{' ' * (max - o.first.to_s.length)} #{o.last}"
+              "  #{o.first}.#{" " * (max - o.first.to_s.length)} #{o.last}"
             else
               o
             end
           end
           ui.info "#{output.join("\n")}\n"
-          response = ui.ask_question('Enter selection: ').to_i
+          response = ui.ask_question("Enter selection: ").to_i
           unless valid[response]
-            ui.fatal 'How about using a real value'
+            ui.fatal "How about using a real value"
             exit 1
           else
             entry = valid[response.to_i]

--- a/lib/sfn/utils/ssher.rb
+++ b/lib/sfn/utils/ssher.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Utils
@@ -15,10 +15,10 @@ module Sfn
       # @return [String, NilClass]
       def remote_file_contents(address, user, path, ssh_opts = {})
         if path.to_s.strip.empty?
-          raise ArgumentError.new 'No file path provided!'
+          raise ArgumentError.new "No file path provided!"
         end
-        require 'net/ssh'
-        content = ''
+        require "net/ssh"
+        content = ""
         ssh_session = Net::SSH.start(address, user, ssh_opts)
         content = ssh_session.exec!("sudo cat #{path}")
         content.empty? ? nil : content

--- a/lib/sfn/utils/stack_exporter.rb
+++ b/lib/sfn/utils/stack_exporter.rb
@@ -1,9 +1,9 @@
 begin
-  require 'chef'
+  require "chef"
 rescue LoadError
   $stderr.puts "WARN: Failed to load Chef. Chef specific features will be disabled!"
 end
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Utils
@@ -14,12 +14,12 @@ module Sfn
       include Sfn::Utils::JSON
 
       # default chef environment name
-      DEFAULT_CHEF_ENVIRONMENT = '_default'
+      DEFAULT_CHEF_ENVIRONMENT = "_default"
       # default instance options
       DEFAULT_OPTIONS = Mash.new(
         :chef_popsicle => true,
-        :ignored_parameters => ['Environment', 'StackCreator', 'Creator'],
-        :chef_environment_parameter => 'Environment',
+        :ignored_parameters => ["Environment", "StackCreator", "Creator"],
+        :chef_environment_parameter => "Environment",
       )
       # default structure of export payload
       DEFAULT_EXPORT_STRUCTURE = {
@@ -33,7 +33,7 @@ module Sfn
         ),
         :generator => {
           :timestamp => Time.now.to_i,
-          :name => 'SparkleFormation',
+          :name => "SparkleFormation",
           :version => Sfn::VERSION.version,
           :provider => nil,
         },
@@ -89,7 +89,7 @@ module Sfn
       # @return [Object]
       def method_missing(*args)
         m = args.first.to_s
-        if m.end_with?('?') && options.has_key?(k = m.sub('?', '').to_sym)
+        if m.end_with?("?") && options.has_key?(k = m.sub("?", "").to_sym)
           !!options[k]
         else
           super
@@ -126,7 +126,7 @@ module Sfn
       # @return [Chef::Environment]
       def environment
         unless @env
-          @env = Chef::Environment.load('_default')
+          @env = Chef::Environment.load("_default")
         end
         @env
       end
@@ -154,9 +154,9 @@ module Sfn
         rl_item = item.is_a?(Chef::RunList::RunListItem) ? item : Chef::RunList::RunListItem.new(item)
         static_content = Mash.new(:run_list => [])
         if rl_item.recipe?
-          cookbook, recipe = rl_item.name.split('::')
+          cookbook, recipe = rl_item.name.split("::")
           peg_version = allowed_cookbook_version(cookbook)
-          static_content[:run_list] << "recipe[#{[cookbook, recipe || 'default'].join('::')}@#{peg_version}]"
+          static_content[:run_list] << "recipe[#{[cookbook, recipe || "default"].join("::")}@#{peg_version}]"
         elsif rl_item.role?
           role = Chef::Role.load(rl_item.name)
           role.run_list.each do |item|
@@ -177,10 +177,10 @@ module Sfn
       # @param first_run [Hash] chef first run hash
       # @return [Hash]
       def unpack_and_freeze_runlist(first_run)
-        extracted_runlists = first_run['run_list'].map do |item|
+        extracted_runlists = first_run["run_list"].map do |item|
           extract_runlist_item(cf_replace(item))
         end
-        first_run.delete('run_list')
+        first_run.delete("run_list")
         first_run.replace(
           extracted_runlists.inject(first_run) do |memo, first_run_item|
             Chef::Mixin::DeepMerge.merge(memo, first_run_item)
@@ -208,8 +208,8 @@ module Sfn
         result = []
         case thing
         when Hash
-          if thing['content'] && thing['content']['run_list']
-            result << thing['content']
+          if thing["content"] && thing["content"]["run_list"]
+            result << thing["content"]
           else
             thing.each do |k, v|
               result += locate_runlists(v)
@@ -230,9 +230,9 @@ module Sfn
       def cf_replace(hsh)
         if hsh.is_a?(Hash)
           case hsh.keys.first
-          when 'Fn::Join'
+          when "Fn::Join"
             cf_join(*hsh.values.first)
-          when 'Ref'
+          when "Ref"
             cf_ref(hsh.values.first)
           else
             hsh

--- a/lib/sfn/utils/stack_parameter_scrubber.rb
+++ b/lib/sfn/utils/stack_parameter_scrubber.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Utils
@@ -7,9 +7,9 @@ module Sfn
 
       # Validate attributes within Parameter blocks
       ALLOWED_PARAMETER_ATTRIBUTES = [
-        'Type', 'Default', 'NoEcho', 'AllowedValues', 'AllowedPattern',
-        'MaxLength', 'MinLength', 'MaxValue', 'MinValue', 'Description',
-        'ConstraintDescription',
+        "Type", "Default", "NoEcho", "AllowedValues", "AllowedPattern",
+        "MaxLength", "MinLength", "MaxValue", "MinValue", "Description",
+        "ConstraintDescription",
       ]
 
       # Clean the parameters of the template
@@ -17,14 +17,14 @@ module Sfn
       # @param template [Hash]
       # @return [Hash] template
       def parameter_scrub!(template)
-        parameters = template['Parameters']
+        parameters = template["Parameters"]
         if parameters
           parameters.each do |name, options|
             options.delete_if do |attribute, value|
               !ALLOWED_PARAMETER_ATTRIBUTES.include?(attribute)
             end
           end
-          template['Parameters'] = parameters
+          template["Parameters"] = parameters
         end
         template
       end

--- a/lib/sfn/utils/stack_parameter_validator.rb
+++ b/lib/sfn/utils/stack_parameter_validator.rb
@@ -1,4 +1,4 @@
-require 'sfn'
+require "sfn"
 
 module Sfn
   module Utils
@@ -9,34 +9,34 @@ module Sfn
 
       # HOT parameter mapping
       HEAT_CONSTRAINT_MAP = {
-        'MaxLength' => [:length, :max],
-        'MinLength' => [:length, :min],
-        'MaxValue' => [:range, :max],
-        'MinValue' => [:range, :min],
-        'AllowedValues' => [:allowed_values],
-        'AllowedPattern' => [:allowed_pattern],
+        "MaxLength" => [:length, :max],
+        "MinLength" => [:length, :min],
+        "MaxValue" => [:range, :max],
+        "MinValue" => [:range, :min],
+        "AllowedValues" => [:allowed_values],
+        "AllowedPattern" => [:allowed_pattern],
       }
 
       # GCDM parameter mapping
       GOOGLE_CONSTRAINT_MAP = {
-        'AllowedPattern' => [:pattern],
-        'MaxValue' => [:maximum],
-        'MinValue' => [:minimum],
+        "AllowedPattern" => [:pattern],
+        "MaxValue" => [:maximum],
+        "MinValue" => [:minimum],
       }
 
       # Parameter mapping identifier and content
       PARAMETER_DEFINITION_MAP = {
-        'constraints' => HEAT_CONSTRAINT_MAP,
+        "constraints" => HEAT_CONSTRAINT_MAP,
       }
 
       # Supported parameter validations
       PARAMETER_VALIDATIONS = [
-        'allowed_values',
-        'allowed_pattern',
-        'max_length',
-        'min_length',
-        'max_value',
-        'min_value',
+        "allowed_values",
+        "allowed_pattern",
+        "max_length",
+        "min_length",
+        "max_value",
+        "min_value",
       ]
 
       # Validate a parameters
@@ -51,12 +51,12 @@ module Sfn
       # @option parameter_definition [String, Integer] 'MinValue'
       # @return [TrueClass, Array<String>] true if valid. array of string errors if invalid
       def validate_parameter(value, parameter_definition)
-        return [[:blank, 'Value cannot be blank']] if value.to_s.strip.empty?
+        return [[:blank, "Value cannot be blank"]] if value.to_s.strip.empty?
         parameter_definition = reformat_definition(parameter_definition)
-        value_list = list_type?(parameter_definition.fetch('Type', parameter_definition['type'].to_s)) ? value.to_s.split(',') : [value]
+        value_list = list_type?(parameter_definition.fetch("Type", parameter_definition["type"].to_s)) ? value.to_s.split(",") : [value]
         result = PARAMETER_VALIDATIONS.map do |validator_key|
           valid_key = parameter_definition.keys.detect do |pdef_key|
-            pdef_key.downcase.gsub('_', '') == validator_key.downcase.gsub('_', '')
+            pdef_key.downcase.gsub("_", "") == validator_key.downcase.gsub("_", "")
           end
           if valid_key
             value_list.map do |value|
@@ -102,7 +102,7 @@ module Sfn
         if pdef.include?(value)
           true
         else
-          "Not an allowed value: #{pdef.join(', ')}"
+          "Not an allowed value: #{pdef.join(", ")}"
         end
       end
 
@@ -182,7 +182,7 @@ module Sfn
       # @return [TrueClass, FalseClass]
       def list_type?(type)
         type = type.downcase
-        type.start_with?('comma') || type.start_with?('list<')
+        type.start_with?("comma") || type.start_with?("list<")
       end
     end
   end

--- a/lib/sfn/version.rb
+++ b/lib/sfn/version.rb
@@ -1,4 +1,4 @@
 module Sfn
   # Current library version
-  VERSION = Gem::Version.new('3.0.31')
+  VERSION = Gem::Version.new("3.0.31")
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,12 +1,12 @@
-require 'sfn'
-require 'bogo-ui'
-require 'minitest/autorun'
-require 'mocha/mini_test'
-require 'tempfile'
-require 'openssl'
+require "sfn"
+require "bogo-ui"
+require "minitest/autorun"
+require "mocha/mini_test"
+require "tempfile"
+require "openssl"
 
 # Stub out HTTP so we can easily intercept remote calls
-require 'http'
+require "http"
 
 module HTTP
   class << self
@@ -41,12 +41,12 @@ module SfnHttpMock
   end
 
   def stream
-    @stream ||= StringIO.new('')
+    @stream ||= StringIO.new("")
   end
 
   def ui
     @ui ||= Bogo::Ui.new(
-      :app_name => 'TestUi',
+      :app_name => "TestUi",
       :output_to => stream,
       :colors => false,
     )
@@ -70,10 +70,10 @@ module SfnHttpMock
   end
 
   def google_creds
-    key_file = Tempfile.new('sfn-test')
+    key_file = Tempfile.new("sfn-test")
     key_path = key_file.path
     key_file.delete
-    key_file = File.open(key_path, 'w')
+    key_file = File.open(key_path, "w")
     key_file.puts OpenSSL::PKey::RSA.new(2048).to_pem
     key_file.close
     @google_key = key_file.path
@@ -99,9 +99,9 @@ module SfnHttpMock
   end
 
   def http_response(opts = {})
-    opts[:version] ||= '1.1'
+    opts[:version] ||= "1.1"
     opts[:status] ||= 200
-    opts[:body] ||= '{}'
+    opts[:body] ||= "{}"
     HTTP::Response.new(opts)
   end
 end

--- a/test/rspecs.rb
+++ b/test/rspecs.rb
@@ -1,1 +1,1 @@
-require 'sfn'
+require "sfn"

--- a/test/rspecs/lib/callback/stack_policy_rspec.rb
+++ b/test/rspecs/lib/callback/stack_policy_rspec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../rspecs'
+require_relative "../../../rspecs"
 
 RSpec.describe Sfn::Callback::StackPolicy do
   let(:ui) { double(:ui) }
@@ -8,14 +8,14 @@ RSpec.describe Sfn::Callback::StackPolicy do
 
   let(:instance) { subject.new(ui, config, arguments, api) }
 
-  context 'with no stack polciies defined' do
+  context "with no stack polciies defined" do
     before do
     end
-    it 'should not error if no policies are defined' do
+    it "should not error if no policies are defined" do
     end
   end
 
-  it 'should fail' do
+  it "should fail" do
     pending
     expect(true).to be false
   end

--- a/test/rspecs/lib/command_module/callbacks_rspec.rb
+++ b/test/rspecs/lib/command_module/callbacks_rspec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../rspecs'
+require_relative "../../../rspecs"
 
 RSpec.describe Sfn::CommandModule::Callbacks do
   let(:ui) { double(:ui) }
@@ -20,7 +20,7 @@ RSpec.describe Sfn::CommandModule::Callbacks do
       end
 
       def self.name
-        'Sfn::Callback::Status'
+        "Sfn::Callback::Status"
       end
     }
   }
@@ -34,52 +34,52 @@ RSpec.describe Sfn::CommandModule::Callbacks do
     allow(ui).to receive(:color)
   end
 
-  describe '#api_action!' do
+  describe "#api_action!" do
     before { allow(instance).to receive(:run_callbacks_for) }
 
-    it 'should run specific and general before and after callbacks' do
+    it "should run specific and general before and after callbacks" do
       expect(instance).to receive(:run_callbacks_for).with(["before_status", :before], any_args)
       expect(instance).to receive(:run_callbacks_for).with(["after_status", :after], any_args)
       instance.api_action!
     end
 
-    it 'should run failed callbacks on error' do
+    it "should run failed callbacks on error" do
       expect(instance).to receive(:run_callbacks_for).with(["before_status", :before], any_args)
       expect(instance).to receive(:run_callbacks_for).with(["failed_status", :failed], any_args)
-      expect { instance.api_action! { raise 'error' } }.to raise_error(RuntimeError)
+      expect { instance.api_action! { raise "error" } }.to raise_error(RuntimeError)
     end
 
-    it 'should provide exception to callbacks on error' do
+    it "should provide exception to callbacks on error" do
       expect(instance).to receive(:run_callbacks_for).with(["failed_status", :failed], instance_of(RuntimeError))
-      expect { instance.api_action! { raise 'error' } }.to raise_error(RuntimeError)
+      expect { instance.api_action! { raise "error" } }.to raise_error(RuntimeError)
     end
   end
 
-  describe '#run_callbacks_for' do
-    let(:callbacks) { ['status'] }
+  describe "#run_callbacks_for" do
+    let(:callbacks) { ["status"] }
 
-    it 'should run the callback' do
+    it "should run the callback" do
       expect_any_instance_of(klass).to receive(:before)
       instance.run_callbacks_for(:before)
     end
   end
 
-  describe '#callbacks_for' do
-    it 'should load callbacks defined within configuration' do
+  describe "#callbacks_for" do
+    it "should load callbacks defined within configuration" do
       expect(config).to receive(:fetch).with(:callbacks, :before, []).and_return([])
       expect(config).to receive(:fetch).with(:callbacks, :default, []).and_return([])
       expect(instance.callbacks_for(:before)).to eq([])
     end
 
-    context 'callback name configured' do
-      let(:callbacks) { ['status'] }
+    context "callback name configured" do
+      let(:callbacks) { ["status"] }
 
-      it 'should lookup callbacks within namespace' do
-        expect(Sfn::Callback).to receive(:const_get).with('Status').and_return(klass)
+      it "should lookup callbacks within namespace" do
+        expect(Sfn::Callback).to receive(:const_get).with("Status").and_return(klass)
         expect(instance.callbacks_for(:before)).to be_a(Array)
       end
 
-      it 'should raise error when class not found' do
+      it "should raise error when class not found" do
         expect(Sfn::Callback).to receive(:const_get).and_call_original
         expect { instance.callbacks_for(:before) }.to raise_error(NameError)
       end

--- a/test/rspecs/sfn_rspec.rb
+++ b/test/rspecs/sfn_rspec.rb
@@ -1,4 +1,4 @@
-require_relative '../rspecs'
+require_relative "../rspecs"
 
 RSpec.describe Sfn do
 end

--- a/test/specs/command/create_spec.rb
+++ b/test/specs/command/create_spec.rb
@@ -1,121 +1,121 @@
-require_relative '../../helper'
-require 'http'
+require_relative "../../helper"
+require "http"
 
 describe Sfn::Command::Create do
-  describe 'AWS' do
-    describe 'default behavior' do
+  describe "AWS" do
+    describe "default behavior" do
       before do
-        $mock.expects(:post).returns(http_response(:body => '{}'))
+        $mock.expects(:post).returns(http_response(:body => "{}"))
       end
 
-      it 'should display create initialize' do
+      it "should display create initialize" do
         instance = Sfn::Command::Create.new(
           Smash.new(
             :ui => ui,
-            :file => 'dummy',
-            :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+            :file => "dummy",
+            :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
             :poll => false,
             :credentials => aws_creds,
-          ), ['test-stack']
+          ), ["test-stack"]
         )
         instance.execute!
         stream.rewind
         output = stream.read
-        output.must_include 'creation initialized for test-stack'
+        output.must_include "creation initialized for test-stack"
       end
     end
 
-    describe 'nesting behavior' do
+    describe "nesting behavior" do
       before do
         $mock.expects(:head).with { |url|
-          url.include?('s3') && url.include?('bucket')
+          url.include?("s3") && url.include?("bucket")
         }.returns(http_response)
       end
 
-      it 'should display human error when no bucket provided' do
+      it "should display human error when no bucket provided" do
         instance = Sfn::Command::Create.new(
           Smash.new(
             :ui => ui,
-            :file => 'nested_dummy',
-            :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+            :file => "nested_dummy",
+            :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
             :poll => false,
             :credentials => aws_creds,
-          ), ['test-stack']
+          ), ["test-stack"]
         )
         -> { instance.execute! }.must_raise StandardError
         stream.rewind
         output = stream.read
-        output.must_include 'Missing required configuration value'
-        output.must_include 'nesting_bucket'
+        output.must_include "Missing required configuration value"
+        output.must_include "nesting_bucket"
       end
 
-      it 'should store nested template in bucket' do
-        $mock.expects(:post).returns(http_response(:body => '{}'))
+      it "should store nested template in bucket" do
+        $mock.expects(:post).returns(http_response(:body => "{}"))
         $mock.expects(:put).with { |url, opts|
-          opts[:body].must_equal({'Value' => true}.to_json)
-          url.include?('s3') && url.end_with?('.json')
+          opts[:body].must_equal({"Value" => true}.to_json)
+          url.include?("s3") && url.end_with?(".json")
         }.returns(http_response)
         $mock.expects(:get).with { |url, opts|
-          url.include?('s3') && url.end_with?('.json')
+          url.include?("s3") && url.end_with?(".json")
         }.returns(http_response)
         instance = Sfn::Command::Create.new(
           Smash.new(
             :ui => ui,
-            :file => 'nested_dummy',
-            :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+            :file => "nested_dummy",
+            :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
             :poll => false,
-            :nesting_bucket => 'bucket',
+            :nesting_bucket => "bucket",
             :credentials => aws_creds,
-          ), ['test-stack']
+          ), ["test-stack"]
         )
         instance.execute!
         stream.rewind
         output = stream.read
-        output.must_include 'creation initialized for test-stack'
+        output.must_include "creation initialized for test-stack"
       end
 
-      it 'should remove stack property from template when using nested stack' do
+      it "should remove stack property from template when using nested stack" do
         $mock.expects(:put).with { |url, opts|
-          opts[:body].must_equal({'Value' => true}.to_json)
-          url.include?('s3') && url.end_with?('.json')
+          opts[:body].must_equal({"Value" => true}.to_json)
+          url.include?("s3") && url.end_with?(".json")
         }.returns(http_response)
         $mock.expects(:get).with { |url, opts|
-          url.include?('s3') && url.end_with?('.json')
+          url.include?("s3") && url.end_with?(".json")
         }.returns(http_response)
         $mock.expects(:post).with { |url, opts|
-          MultiJson.load(opts.to_smash.get(:form, 'TemplateBody')).to_smash.get(
-            'Resources', 'Dummy', 'Properties', 'Stack'
+          MultiJson.load(opts.to_smash.get(:form, "TemplateBody")).to_smash.get(
+            "Resources", "Dummy", "Properties", "Stack"
           ).must_be_nil
-          opts.to_smash.get(:form, 'Action') == 'CreateStack'
-        }.returns(http_response(:body => '{}'))
+          opts.to_smash.get(:form, "Action") == "CreateStack"
+        }.returns(http_response(:body => "{}"))
         instance = Sfn::Command::Create.new(
           Smash.new(
             :ui => ui,
-            :file => 'nested_dummy',
-            :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+            :file => "nested_dummy",
+            :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
             :poll => false,
-            :nesting_bucket => 'bucket',
+            :nesting_bucket => "bucket",
             :credentials => aws_creds,
-          ), ['test-stack']
+          ), ["test-stack"]
         )
         instance.execute!
       end
     end
   end
 
-  describe 'Azure' do
+  describe "Azure" do
     let(:azure_container_result) do
       Smash.new(
-        'EnumerationResults' => {
-          'Containers' => {
-            'Container' => [
+        "EnumerationResults" => {
+          "Containers" => {
+            "Container" => [
               Smash.new(
-                'Name' => 'miasma-orchestration-templates',
-                'Properties' => {
-                  'Last_Modified' => Time.now.rfc2822,
-                  'Etag' => '"0000"',
-                  'LeaseStatus' => 'unlocked',
-                  'LeaseState' => 'available',
+                "Name" => "miasma-orchestration-templates",
+                "Properties" => {
+                  "Last_Modified" => Time.now.rfc2822,
+                  "Etag" => '"0000"',
+                  "LeaseStatus" => "unlocked",
+                  "LeaseState" => "available",
                 },
               ),
             ],
@@ -126,26 +126,26 @@ describe Sfn::Command::Create do
 
     let(:azure_create_resource_group) do
       Smash.new(
-        :id => '/resource-group-id/test-stack',
-        :name => 'test-stack',
-        :location => 'AZURE_REGION',
+        :id => "/resource-group-id/test-stack",
+        :name => "test-stack",
+        :location => "AZURE_REGION",
         :tags => {
           :created => Time.now.to_i,
-          :state => 'create',
+          :state => "create",
         },
         :properties => {
-          :provisioningState => 'Succeeded',
+          :provisioningState => "Succeeded",
         },
       )
     end
 
     let(:azure_create_deployment) do
       Smash.new(
-        :id => '/deployment-id/miasma-stack',
-        :name => 'miasma-stack',
+        :id => "/deployment-id/miasma-stack",
+        :name => "miasma-stack",
         :properties => {
-          :mode => 'Complete',
-          :provisioningState => 'Accepted',
+          :mode => "Complete",
+          :provisioningState => "Accepted",
           :timestamp => Time.now.xmlschema,
         },
       )
@@ -155,79 +155,79 @@ describe Sfn::Command::Create do
       Smash.new(
         :expires_on => Time.now.to_i + 900,
         :not_before => Time.now.to_i - 900,
-        :access_token => 'AZURE_TOKEN',
+        :access_token => "AZURE_TOKEN",
       )
     end
 
     before do
       $mock.expects(:post).with { |url|
-        url.include?('oauth2')
+        url.include?("oauth2")
       }.returns(http_response(:body => azure_client_access_token.to_json)).once
       $mock.expects(:get).with { |url, opts = {}|
-        url.include?('blob') && opts.fetch(:params, {})['comp'] == 'list'
+        url.include?("blob") && opts.fetch(:params, {})["comp"] == "list"
       }.returns(http_response(:body => azure_container_result.to_json))
       $mock.expects(:put).with { |url|
-        url.include?('blob')
+        url.include?("blob")
       }.returns(http_response(:status => 201))
       $mock.expects(:head).with { |url|
-        url.include?('blob')
+        url.include?("blob")
       }.returns(http_response)
       $mock.expects(:put).with { |url|
-        url.end_with?('resourcegroups/test-stack')
+        url.end_with?("resourcegroups/test-stack")
       }.returns(http_response(:body => azure_create_resource_group.to_json))
       $mock.expects(:put).with { |url|
-        url.end_with?('deployments/miasma-stack')
+        url.end_with?("deployments/miasma-stack")
       }.returns(http_response(:body => azure_create_deployment.to_json))
     end
 
-    describe 'default behavior' do
-      it 'should display create initialize' do
+    describe "default behavior" do
+      it "should display create initialize" do
         instance = Sfn::Command::Create.new(
           Smash.new(
             :ui => ui,
-            :file => 'dummy_azure',
-            :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+            :file => "dummy_azure",
+            :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
             :poll => false,
             :credentials => azure_creds,
-          ), ['test-stack']
+          ), ["test-stack"]
         )
         instance.execute!
         stream.rewind
         output = stream.read
-        output.must_include 'creation initialized for test-stack'
+        output.must_include "creation initialized for test-stack"
       end
     end
 
-    describe 'nesting behavior' do
-      it 'should display human error when no bucket provided' do
+    describe "nesting behavior" do
+      it "should display human error when no bucket provided" do
         instance = Sfn::Command::Create.new(
           Smash.new(
             :ui => ui,
-            :file => 'nested_dummy_azure',
-            :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+            :file => "nested_dummy_azure",
+            :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
             :poll => false,
             :credentials => azure_creds,
-          ), ['test-stack']
+          ), ["test-stack"]
         )
         -> { instance.execute! }.must_raise StandardError
         stream.rewind
         output = stream.read
-        output.must_include 'Missing required configuration value'
-        output.must_include 'nesting_bucket'
+        output.must_include "Missing required configuration value"
+        output.must_include "nesting_bucket"
       end
 
-      it 'should store nested template in bucket' do
+      it "should store nested template in bucket" do
         $mock.expects(:put).with { |url, opts|
-          if url.end_with?('test-stack_dummyAzure.json')
-            opts[:body].must_equal({'value' => true}.to_json)
+          if url.end_with?("test-stack_dummyAzure.json")
+            opts[:body].must_equal({"value" => true}.to_json)
             true
           end
         }.returns(http_response(:status => 201))
         $mock.expects(:head).with { |url, opts|
-          url.end_with?('test-stack_dummyAzure.json')
+          url.end_with?("test-stack_dummyAzure.json")
         }.returns(http_response)
         $mock.expects(:put).with { |url, opts|
-          if url.include?('blob') && url.include?('test-stack-') && url.include?('.json')
+          if url.include?("blob") && url.include?("test-stack-") && url.include?(".json")
             MultiJson.load(opts[:body]).to_smash.fetch(:resources, [{}]).first.get(:properties, :stack).must_be_nil
             true
           end
@@ -235,30 +235,30 @@ describe Sfn::Command::Create do
         instance = Sfn::Command::Create.new(
           Smash.new(
             :ui => ui,
-            :file => 'nested_dummy_azure',
-            :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+            :file => "nested_dummy_azure",
+            :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
             :poll => false,
-            :nesting_bucket => 'miasma-orchestration-templates',
+            :nesting_bucket => "miasma-orchestration-templates",
             :credentials => azure_creds,
-          ), ['test-stack']
+          ), ["test-stack"]
         )
         instance.execute!
         stream.rewind
         output = stream.read
-        output.must_include 'creation initialized for test-stack'
+        output.must_include "creation initialized for test-stack"
       end
 
-      it 'should remove stack property from template when using nested stack' do
+      it "should remove stack property from template when using nested stack" do
         $mock.expects(:put).with { |url, opts|
-          if url.end_with?('test-stack_dummyAzure.json')
+          if url.end_with?("test-stack_dummyAzure.json")
             true
           end
         }.returns(http_response(:status => 201))
         $mock.expects(:head).with { |url, opts|
-          url.end_with?('test-stack_dummyAzure.json')
+          url.end_with?("test-stack_dummyAzure.json")
         }.returns(http_response)
         $mock.expects(:put).with { |url, opts|
-          if url.include?('blob') && url.include?('test-stack-') && url.include?('.json')
+          if url.include?("blob") && url.include?("test-stack-") && url.include?(".json")
             MultiJson.load(opts[:body]).to_smash.fetch(:resources, [{}]).first.get(:properties, :stack).must_be_nil
             true
           end
@@ -266,35 +266,35 @@ describe Sfn::Command::Create do
         instance = Sfn::Command::Create.new(
           Smash.new(
             :ui => ui,
-            :file => 'nested_dummy_azure',
-            :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+            :file => "nested_dummy_azure",
+            :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
             :poll => false,
-            :nesting_bucket => 'miasma-orchestration-templates',
+            :nesting_bucket => "miasma-orchestration-templates",
             :credentials => azure_creds,
-          ), ['test-stack']
+          ), ["test-stack"]
         )
         instance.execute!
       end
     end
   end
 
-  describe 'Google' do
+  describe "Google" do
     let(:google_auth_token) do
       Smash.new(
-        :access_token => 'TOKEN',
-        :token_type => 'TYPE',
+        :access_token => "TOKEN",
+        :token_type => "TYPE",
         :expires_in => 300,
       )
     end
 
     let(:google_create_deployment) do
       Smash.new(
-        :kind => 'deploymentmanager#operation',
-        :id => 'operation-id',
-        :name => 'deployment-operation',
-        :operationType => 'insert',
-        :targetLink => 'http://example.com/deployments/test-stack',
-        :status => 'PENDING',
+        :kind => "deploymentmanager#operation",
+        :id => "operation-id",
+        :name => "deployment-operation",
+        :operationType => "insert",
+        :targetLink => "http://example.com/deployments/test-stack",
+        :status => "PENDING",
         :progress => 0,
         :startTime => Time.now.xmlschema,
       )
@@ -302,19 +302,19 @@ describe Sfn::Command::Create do
 
     let(:google_get_deployment) do
       Smash.new(
-        :id => 'test-stack-id',
-        :name => 'test-stack',
+        :id => "test-stack-id",
+        :name => "test-stack",
         :insertTime => Time.now.xmlschema,
         :operation => {
-          :id => 'operation-id',
-          :operationType => 'insert',
-          :status => 'RUNNING',
+          :id => "operation-id",
+          :operationType => "insert",
+          :status => "RUNNING",
           :progress => 0,
           :startTime => Time.now.xmlschema,
         },
-        :fingerprint => 'FINGERPRINT-ID',
+        :fingerprint => "FINGERPRINT-ID",
         :update => {
-          :manifest => 'http://example.com/manifests/test-stack.manifest',
+          :manifest => "http://example.com/manifests/test-stack.manifest",
         },
       )
     end
@@ -325,58 +325,58 @@ describe Sfn::Command::Create do
 
     before do
       $mock.expects(:post).with { |url, opts|
-        url.include?('oauth2')
+        url.include?("oauth2")
       }.returns(http_response(:body => google_auth_token.to_json)).once
       $mock.expects(:get).with { |url|
-        url.end_with?('/deployments/test-stack')
+        url.end_with?("/deployments/test-stack")
       }.returns(http_response(:body => google_get_deployment.to_json))
       $mock.expects(:get).with { |url|
-        url.end_with?('/manifests/test-stack.manifest/')
+        url.end_with?("/manifests/test-stack.manifest/")
       }.returns(http_response(:body => google_get_manifest.to_json))
     end
 
-    describe 'default behavior' do
-      it 'should display create initialize' do
+    describe "default behavior" do
+      it "should display create initialize" do
         $mock.expects(:post).with { |url, opts|
-          url.end_with?('/deployments') &&
-            opts[:json]['name'] == 'test-stack'
+          url.end_with?("/deployments") &&
+            opts[:json]["name"] == "test-stack"
         }.returns(http_response(:body => google_create_deployment.to_json))
         instance = Sfn::Command::Create.new(
           Smash.new(
             :ui => ui,
-            :file => 'dummy_google',
-            :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+            :file => "dummy_google",
+            :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
             :poll => false,
             :credentials => google_creds,
-          ), ['test-stack']
+          ), ["test-stack"]
         )
         instance.execute!
         stream.rewind
         output = stream.read
-        output.must_include 'creation initialized for test-stack'
+        output.must_include "creation initialized for test-stack"
       end
     end
 
-    describe 'nesting behavior' do
-      it 'should remove stack property from template when using nested stack' do
+    describe "nesting behavior" do
+      it "should remove stack property from template when using nested stack" do
         $mock.expects(:post).with { |url, opts|
-          if url.end_with?('/deployments') && opts[:json]['name'] == 'test-stack'
-            import = opts[:json]['target']['imports'].detect do |i|
-              i['name'] == 'test-stack.jinja'
+          if url.end_with?("/deployments") && opts[:json]["name"] == "test-stack"
+            import = opts[:json]["target"]["imports"].detect do |i|
+              i["name"] == "test-stack.jinja"
             end
-            template = YAML.load(import['content'])
-            template['resources'].first.fetch(:properties, {}).keys.wont_include 'stack'
+            template = YAML.load(import["content"])
+            template["resources"].first.fetch(:properties, {}).keys.wont_include "stack"
             true
           end
         }.returns(http_response(:body => google_create_deployment.to_json))
         instance = Sfn::Command::Create.new(
           Smash.new(
             :ui => ui,
-            :file => 'nested_dummy_google',
-            :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+            :file => "nested_dummy_google",
+            :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
             :poll => false,
             :credentials => google_creds,
-          ), ['test-stack']
+          ), ["test-stack"]
         )
         instance.execute!
       end

--- a/test/specs/command/describe_spec.rb
+++ b/test/specs/command/describe_spec.rb
@@ -1,28 +1,28 @@
-require_relative '../../helper'
+require_relative "../../helper"
 
 describe Sfn::Command::Describe do
   let(:creds) { Smash.new }
   let(:credentials) { Smash.new(:credentials => creds) }
 
-  describe 'AWS' do
+  describe "AWS" do
     let(:creds) { aws_creds }
     let(:aws_describe_stacks) do
       res = Smash.new
-      res.set('DescribeStacksResponse', 'DescribeStacksResult', 'Stacks', 'member',
+      res.set("DescribeStacksResponse", "DescribeStacksResult", "Stacks", "member",
               Smash.new(
-        'Outputs' => {
-          'member' => [
-            Smash.new('OutputKey' => 'test-output', 'OutputValue' => 'test-output-value'),
+        "Outputs" => {
+          "member" => [
+            Smash.new("OutputKey" => "test-output", "OutputValue" => "test-output-value"),
           ],
         },
-        'CreationTime' => Time.now.xmlschema,
-        'StackName' => 'test-stack',
-        'StackId' => 'arn:aws:cloudformation:REGION:ACCT_ID:stack/test-stack/UUID',
-        'StackStatus' => 'CREATE_COMPLETE',
-        'Tags' => {
-          'member' => {
-            "Key" => 'test-tag',
-            "Value" => 'test-tag-value',
+        "CreationTime" => Time.now.xmlschema,
+        "StackName" => "test-stack",
+        "StackId" => "arn:aws:cloudformation:REGION:ACCT_ID:stack/test-stack/UUID",
+        "StackStatus" => "CREATE_COMPLETE",
+        "Tags" => {
+          "member" => {
+            "Key" => "test-tag",
+            "Value" => "test-tag-value",
           },
         },
       ))
@@ -30,74 +30,74 @@ describe Sfn::Command::Describe do
     end
     let(:aws_list_resources) do
       res = Smash.new
-      res.set('ListStackResourcesResponse', 'ListStackResourcesResult', 'StackResourceSummaries', 'member', [
-        'LastUpdatedTimestamp' => Time.now.xmlschema,
-        'PhysicalResourceId' => 'TestStackResourceId',
-        'LogicalResourceId' => 'TestStackResource',
-        'ResourceStatus' => 'CREATE_COMPLETE',
-        'ResourceType' => 'Custom::TestResource',
+      res.set("ListStackResourcesResponse", "ListStackResourcesResult", "StackResourceSummaries", "member", [
+        "LastUpdatedTimestamp" => Time.now.xmlschema,
+        "PhysicalResourceId" => "TestStackResourceId",
+        "LogicalResourceId" => "TestStackResource",
+        "ResourceStatus" => "CREATE_COMPLETE",
+        "ResourceType" => "Custom::TestResource",
       ])
       res
     end
 
     before do
       $mock.expects(:post).with { |url, opts|
-        opts.to_smash.get(:form, 'Action') == 'DescribeStacks'
+        opts.to_smash.get(:form, "Action") == "DescribeStacks"
       }.returns(http_response(:body => aws_describe_stacks.to_json)).once
       $mock.expects(:post).with { |url, opts|
-        opts.to_smash.get(:form, 'Action') == 'ListStackResources'
+        opts.to_smash.get(:form, "Action") == "ListStackResources"
       }.returns(http_response(:body => aws_list_resources.to_json)).once
     end
 
-    it 'should display outputs' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should display outputs" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'Test Output'
-      output.must_include 'test-output-value'
+      output.must_include "Test Output"
+      output.must_include "test-output-value"
     end
 
-    it 'should display resources' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should display resources" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'TestStackResource'
-      output.must_include 'Custom::TestResource'
+      output.must_include "TestStackResource"
+      output.must_include "Custom::TestResource"
     end
 
-    it 'should display tags' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should display tags" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'test-tag'
-      output.must_include 'test-tag-value'
+      output.must_include "test-tag"
+      output.must_include "test-tag-value"
     end
   end
 
-  describe 'Google' do
+  describe "Google" do
     let(:creds) { google_creds }
     let(:google_get_deployments) do
       Smash.new(
         :deployments => [
           Smash.new(
-            :id => '11111',
+            :id => "11111",
             :insertTime => Time.now.xmlschema,
-            :selfLink => 'http://example.com',
-            :name => 'test-stack',
+            :selfLink => "http://example.com",
+            :name => "test-stack",
             :operation => {
-              :id => '222222',
-              :name => 'test-stack-operation',
-              :operationType => 'update',
-              :status => 'DONE',
+              :id => "222222",
+              :name => "test-stack-operation",
+              :operationType => "update",
+              :status => "DONE",
               :progress => 100,
               :startTime => Time.now.xmlschema,
               :endTime => Time.now.xmlschema,
             },
-            :fingerprint => '9999',
-            :manifest => 'http://example.com/test-stack.manifest',
+            :fingerprint => "9999",
+            :manifest => "http://example.com/test-stack.manifest",
           ),
         ],
       )
@@ -106,96 +106,96 @@ describe Sfn::Command::Describe do
       Smash.new(
         :resources => [
           {
-            :id => '33333',
+            :id => "33333",
             :insertTime => Time.now.xmlschema,
             :updateTime => Time.now.xmlschema,
-            :name => 'testResource',
-            :type => 'custom.v1.resource',
+            :name => "testResource",
+            :type => "custom.v1.resource",
           },
         ],
       )
     end
     let(:google_get_manifest) do
       Smash.new(
-        :id => '11111',
-        :selfLink => 'http://example.com',
+        :id => "11111",
+        :selfLink => "http://example.com",
         :insertTime => Time.now.xmlschema,
-        :name => 'manifest-test-stack',
+        :name => "manifest-test-stack",
         :config => {
           :content => {
-            'resources' => [{'name' => 'test-resource', 'type' => 'test-type'}],
+            "resources" => [{"name" => "test-resource", "type" => "test-type"}],
           }.to_yaml,
         },
         :imports => [
-          {:name => 'test-file', :content => {'resources' => []}.to_yaml},
+          {:name => "test-file", :content => {"resources" => []}.to_yaml},
         ],
         :expandedConfig => {}.to_yaml,
-        :layout => {'outputs' => [{'name' => 'test-output', 'finalValue' => 'test-output-value'}]}.to_yaml,
+        :layout => {"outputs" => [{"name" => "test-output", "finalValue" => "test-output-value"}]}.to_yaml,
       )
     end
     let(:google_auth_token) do
       Smash.new(
-        :access_token => 'TOKEN',
-        :token_type => 'TYPE',
+        :access_token => "TOKEN",
+        :token_type => "TYPE",
         :expires_in => 300,
       )
     end
 
     before do
       $mock.expects(:get).with { |url|
-        url.end_with?('deployments')
+        url.end_with?("deployments")
       }.returns(http_response(:body => google_get_deployments.to_json)).once
       $mock.expects(:get).with { |url|
-        url.include?('deployments') && url.include?('test-stack')
+        url.include?("deployments") && url.include?("test-stack")
       }.returns(http_response(:body => google_get_deployments[:deployments].first.to_json)).at_least_once
       $mock.expects(:get).with { |url|
-        url.include?('manifest')
+        url.include?("manifest")
       }.returns(http_response(:body => google_get_manifest.to_json)).at_least_once
       $mock.expects(:post).with { |url, opts|
-        url.include?('oauth2')
+        url.include?("oauth2")
       }.returns(http_response(:body => google_auth_token.to_json)).once
       $mock.expects(:get).with { |url|
-        url.include?('resources')
+        url.include?("resources")
       }.returns(http_response(:body => google_get_resources.to_json)).once
     end
 
-    it 'should display outputs' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should display outputs" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'Test Output'
-      output.must_include 'test-output-value'
+      output.must_include "Test Output"
+      output.must_include "test-output-value"
     end
 
-    it 'should display resources' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should display resources" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'testResource'
-      output.must_include 'custom.v1.resource'
+      output.must_include "testResource"
+      output.must_include "custom.v1.resource"
     end
 
-    it 'should not display tags' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should not display tags" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'No tags'
+      output.must_include "No tags"
     end
   end
 
-  describe 'Azure' do
+  describe "Azure" do
     let(:creds) { azure_creds }
     let(:azure_get_resource_groups) do
       Smash.new(
         :value => [
           Smash.new(
-            :id => 'test-stack-id',
-            :name => 'test-stack',
+            :id => "test-stack-id",
+            :name => "test-stack",
             :properties => {
-              :provisioningState => 'Succeeded',
+              :provisioningState => "Succeeded",
             },
           ),
         ],
@@ -203,16 +203,16 @@ describe Sfn::Command::Describe do
     end
     let(:azure_get_resource_group) do
       Smash.new(
-        :id => 'test-stack-id',
-        :name => 'tset-stack',
+        :id => "test-stack-id",
+        :name => "tset-stack",
         :properties => {
-          :mode => 'Complete',
-          :provisioningState => 'Succeeded',
+          :mode => "Complete",
+          :provisioningState => "Succeeded",
           :timestamp => Time.now.xmlschema,
           :outputs => {
-            'testOutput' => {
-              :type => 'string',
-              :value => 'test-output-value',
+            "testOutput" => {
+              :type => "string",
+              :value => "test-output-value",
             },
           },
         },
@@ -222,10 +222,10 @@ describe Sfn::Command::Describe do
       Smash.new(
         :value => [
           Smash.new(
-            :id => 'test-resource-id',
-            :name => 'testResource',
-            :type => 'Custom/testResource',
-            :location => 'here',
+            :id => "test-resource-id",
+            :name => "testResource",
+            :type => "Custom/testResource",
+            :location => "here",
           ),
         ],
       )
@@ -234,16 +234,16 @@ describe Sfn::Command::Describe do
       Smash.new(
         :value => [
           Smash.new(
-            :id => 'test-resource-operation-id',
-            :operationId => 'operation-id',
+            :id => "test-resource-operation-id",
+            :operationId => "operation-id",
             :properties => {
-              :provisioningState => 'Succeeded',
+              :provisioningState => "Succeeded",
               :timestamp => Time.now.xmlschema,
-              :statusCode => 'OK',
+              :statusCode => "OK",
               :targetResource => {
-                :id => 'test-resource-id',
-                :resourceName => 'testResource',
-                :resourceType => 'Custom/testResource',
+                :id => "test-resource-id",
+                :resourceName => "testResource",
+                :resourceType => "Custom/testResource",
               },
             },
           ),
@@ -254,68 +254,68 @@ describe Sfn::Command::Describe do
       Smash.new(
         :expires_on => Time.now.to_i + 900,
         :not_before => Time.now.to_i - 900,
-        :access_token => 'AZURE_TOKEN',
+        :access_token => "AZURE_TOKEN",
       )
     end
 
     before do
       $mock.expects(:post).with { |url|
-        url.include?('oauth2')
+        url.include?("oauth2")
       }.returns(http_response(:body => azure_client_access_token.to_json)).once
       $mock.expects(:get).with { |url|
-        url.end_with?('resourcegroups')
+        url.end_with?("resourcegroups")
       }.returns(http_response(:body => azure_get_resource_groups.to_json)).once
       $mock.expects(:get).with { |url|
-        url.include?('microsoft.resources')
+        url.include?("microsoft.resources")
       }.returns(http_response(:body => azure_get_resource_group.to_json)).once
       $mock.expects(:get).with { |url|
-        url.end_with?('test-stack/resources')
+        url.end_with?("test-stack/resources")
       }.returns(http_response(:body => azure_get_resources.to_json)).once
       $mock.expects(:get).with { |url|
-        url.include?('operations')
+        url.include?("operations")
       }.returns(http_response(:body => azure_get_resource_operations.to_json)).once
     end
 
-    it 'should display outputs' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should display outputs" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'Test Output'
-      output.must_include 'test-output-value'
+      output.must_include "Test Output"
+      output.must_include "test-output-value"
     end
 
-    it 'should display resources' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should display resources" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'testResource'
-      output.must_include 'Custom/testResource'
+      output.must_include "testResource"
+      output.must_include "Custom/testResource"
     end
 
-    it 'should not display tags' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should not display tags" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'No tags'
+      output.must_include "No tags"
     end
   end
 
-  describe 'Rackspace' do
+  describe "Rackspace" do
     let(:creds) { rackspace_creds }
     let(:rackspace_get_stacks) do
       Smash.new(
         :stacks => [
           Smash.new(
-            :stack_name => 'test-stack',
-            :id => 'test-stack-id',
+            :stack_name => "test-stack",
+            :id => "test-stack-id",
             :creation_time => Time.now.xmlschema,
             :tags => {
-              'test-tag' => 'test-tag-value',
+              "test-tag" => "test-tag-value",
             },
-            :stack_status => 'CREATE_COMPLETE',
+            :stack_status => "CREATE_COMPLETE",
           ),
         ],
       )
@@ -324,14 +324,14 @@ describe Sfn::Command::Describe do
       Smash.new(
         :resources => [
           Smash.new(
-            :resource_name => 'test_resource',
-            :logical_resource_id => 'test_resource',
-            :physical_resource_id => 'test-resource-id',
+            :resource_name => "test_resource",
+            :logical_resource_id => "test_resource",
+            :physical_resource_id => "test-resource-id",
             :creation_time => Time.now.xmlschema,
-            :resource_status => 'CREATE_COMPLETE',
+            :resource_status => "CREATE_COMPLETE",
             :updated_time => Time.now.xmlschema,
-            :resource_status_reason => 'state changed',
-            :resource_type => 'Custom::TestResource',
+            :resource_status_reason => "state changed",
+            :resource_type => "Custom::TestResource",
           ),
         ],
       )
@@ -339,17 +339,17 @@ describe Sfn::Command::Describe do
     let(:rackspace_get_stack) do
       Smash.new(
         :stack => {
-          :stack_name => 'test-stack',
-          :id => 'test-stack-id',
+          :stack_name => "test-stack",
+          :id => "test-stack-id",
           :tags => {
-            'test-tag' => 'test-tag-value',
+            "test-tag" => "test-tag-value",
           },
           :creation_time => Time.now.xmlschema,
-          :stack_status => 'CREATE_COMPLETE',
+          :stack_status => "CREATE_COMPLETE",
           :outputs => [
             Smash.new(
-              :output_key => 'test-output',
-              :output_value => 'test-output-value',
+              :output_key => "test-output",
+              :output_value => "test-output-value",
             ),
           ],
         },
@@ -358,21 +358,21 @@ describe Sfn::Command::Describe do
     let(:rackspace_token_info) do
       Smash.new(
         :access => {
-          :user => 'USERNAME',
+          :user => "USERNAME",
           :serviceCatalog => [
             Smash.new(
-              :name => 'cloudOrchestration',
+              :name => "cloudOrchestration",
               :endpoints => [
                 Smash.new(
-                  :region => 'RACKSPACE_REGION',
-                  :publicURL => 'http://example.com/rackspace',
+                  :region => "RACKSPACE_REGION",
+                  :publicURL => "http://example.com/rackspace",
                 ),
               ],
             ),
           ],
           :token => {
             :expires => (Time.now + 200).xmlschema,
-            :id => 'RACKSPACE_TOKEN',
+            :id => "RACKSPACE_TOKEN",
           },
         },
       )
@@ -380,45 +380,45 @@ describe Sfn::Command::Describe do
 
     before do
       $mock.expects(:post).with { |url|
-        url.include?('tokens')
+        url.include?("tokens")
       }.returns(http_response(:body => rackspace_token_info.to_json))
       $mock.expects(:get).with { |url|
-        url.end_with?('stacks')
+        url.end_with?("stacks")
       }.returns(http_response(:body => rackspace_get_stacks.to_json))
       $mock.expects(:get).with { |url|
-        url.end_with?('resources')
+        url.end_with?("resources")
       }.returns(http_response(:body => rackspace_get_stack_resources.to_json))
       $mock.expects(:get).with { |url|
-        url.end_with?('stacks/test-stack/test-stack-id')
+        url.end_with?("stacks/test-stack/test-stack-id")
       }.returns(http_response(:body => rackspace_get_stack.to_json)).at_least_once
     end
 
-    it 'should display outputs' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should display outputs" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'Test Output'
-      output.must_include 'test-output-value'
+      output.must_include "Test Output"
+      output.must_include "test-output-value"
     end
 
-    it 'should display resources' do
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should display resources" do
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'test_resource'
-      output.must_include 'Custom::TestResource'
+      output.must_include "test_resource"
+      output.must_include "Custom::TestResource"
     end
 
-    it 'should display tags' do
-      skip 'Tags not yet implemented in miasma'
-      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ['test-stack'])
+    it "should display tags" do
+      skip "Tags not yet implemented in miasma"
+      instance = Sfn::Command::Describe.new({:ui => ui}.merge(credentials), ["test-stack"])
       instance.execute!
       stream.rewind
       output = stream.read
-      output.must_include 'Test tag'
-      output.must_include 'test-tag-value'
+      output.must_include "Test tag"
+      output.must_include "test-tag-value"
     end
   end
 end

--- a/test/specs/command/lint_spec.rb
+++ b/test/specs/command/lint_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../helper'
+require_relative "../../helper"
 
 describe Sfn::Command::Lint do
   let(:creds) { aws_creds }
@@ -6,48 +6,48 @@ describe Sfn::Command::Lint do
   before do
     rs = Sfn::Lint::RuleSet.build(:resource_check) do
       rule :aws_resources_only do
-        definition 'Resources.[*][0][*].Type' do |search|
+        definition "Resources.[*][0][*].Type" do |search|
           unless search.nil?
-            result = search.find_all { |i| !i.start_with?('AWS') }
+            result = search.find_all { |i| !i.start_with?("AWS") }
             result.empty? ? true : result
           else
             true
           end
         end
 
-        fail_message 'All types must be within AWS root namespace'
+        fail_message "All types must be within AWS root namespace"
       end
     end
     Sfn::Lint::RuleSet.register(rs)
   end
 
-  it 'should successfully run on valid template' do
+  it "should successfully run on valid template" do
     instance = Sfn::Command::Lint.new(
       Smash.new(
         :ui => ui,
-        :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+        :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
         :credentials => aws_creds,
-        :file => 'lint_valid',
+        :file => "lint_valid",
       ),
       []
     )
     instance.execute!
     stream.rewind
-    stream.read.must_include 'VALID'
+    stream.read.must_include "VALID"
   end
 
-  it 'should fail on invalid template' do
+  it "should fail on invalid template" do
     instance = Sfn::Command::Lint.new(
       Smash.new(
         :ui => ui,
-        :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+        :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
         :credentials => aws_creds,
-        :file => 'lint_invalid',
+        :file => "lint_invalid",
       ),
       []
     )
     -> { instance.execute! }.must_raise RuntimeError
     stream.rewind
-    stream.read.must_include 'INVALID'
+    stream.read.must_include "INVALID"
   end
 end

--- a/test/specs/command/print_spec.rb
+++ b/test/specs/command/print_spec.rb
@@ -1,18 +1,18 @@
-require_relative '../../helper'
+require_relative "../../helper"
 
 describe Sfn::Command::Print do
-  it 'should print the template only' do
+  it "should print the template only" do
     instance = Sfn::Command::Print.new(
       Smash.new(
         :ui => ui,
-        :base_directory => File.join(File.dirname(__FILE__), 'sparkleformation'),
+        :base_directory => File.join(File.dirname(__FILE__), "sparkleformation"),
         :credentials => aws_creds,
-        :file => 'lint_valid',
+        :file => "lint_valid",
       ),
       []
     )
     instance.execute!
     stream.rewind
-    stream.read.start_with?('{').must_equal true
+    stream.read.start_with?("{").must_equal true
   end
 end

--- a/test/specs/command/sparkleformation/lint_invalid.rb
+++ b/test/specs/command/sparkleformation/lint_invalid.rb
@@ -1,4 +1,4 @@
 SparkleFormation.new(:lint_invalid) do
   dynamic!(:s3_bucket, :test)
-  resources.bad_resource.type 'Invalid::Resource'
+  resources.bad_resource.type "Invalid::Resource"
 end

--- a/test/specs/command_module/stack_spec.rb
+++ b/test/specs/command_module/stack_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../helper'
+require_relative "../../helper"
 
 describe Sfn::CommandModule::Stack do
   before do
@@ -18,49 +18,49 @@ describe Sfn::CommandModule::Stack do
 
   let(:instance) { @instance ||= @stack.new }
 
-  describe 'Parameter population helpers' do
-    describe 'Config parameters location' do
+  describe "Parameter population helpers" do
+    describe "Config parameters location" do
       before do
-        instance.config.set(:parameters, :nested__StackItem__MyParameter, 'value')
-        instance.config.set(:parameters, :NotNestedParameter, 'value')
-        instance.config.set(:parameters, :snake_cased_parameter, 'value')
+        instance.config.set(:parameters, :nested__StackItem__MyParameter, "value")
+        instance.config.set(:parameters, :NotNestedParameter, "value")
+        instance.config.set(:parameters, :snake_cased_parameter, "value")
       end
 
-      it 'should match camel cased parameter' do
-        instance.locate_config_parameter_key([], 'NotNestedParameter', 'root').must_equal 'NotNestedParameter'
-        instance.config.get(:parameters, 'NotNestedParameter').must_equal 'value'
+      it "should match camel cased parameter" do
+        instance.locate_config_parameter_key([], "NotNestedParameter", "root").must_equal "NotNestedParameter"
+        instance.config.get(:parameters, "NotNestedParameter").must_equal "value"
       end
 
-      it 'should match snake cased parameter when camel cased' do
-        instance.locate_config_parameter_key([], 'not_nested_parameter', 'root').must_equal 'not_nested_parameter'
-        instance.config.get(:parameters, 'NotNestedParameter').must_be_nil
-        instance.config.get(:parameters, :not_nested_parameter).must_equal 'value'
+      it "should match snake cased parameter when camel cased" do
+        instance.locate_config_parameter_key([], "not_nested_parameter", "root").must_equal "not_nested_parameter"
+        instance.config.get(:parameters, "NotNestedParameter").must_be_nil
+        instance.config.get(:parameters, :not_nested_parameter).must_equal "value"
       end
 
-      it 'should match snake cased parameter' do
-        instance.locate_config_parameter_key([], 'snake_cased_parameter', 'root').must_equal 'snake_cased_parameter'
-        instance.config.get(:parameters, :snake_cased_parameter).must_equal 'value'
+      it "should match snake cased parameter" do
+        instance.locate_config_parameter_key([], "snake_cased_parameter", "root").must_equal "snake_cased_parameter"
+        instance.config.get(:parameters, :snake_cased_parameter).must_equal "value"
       end
 
-      it 'should match camel cased parameter when snake cased' do
-        instance.locate_config_parameter_key([], 'SnakeCasedParameter', 'root').must_equal 'SnakeCasedParameter'
+      it "should match camel cased parameter when snake cased" do
+        instance.locate_config_parameter_key([], "SnakeCasedParameter", "root").must_equal "SnakeCasedParameter"
         instance.config.get(:parameters, :snake_cased_parameter).must_be_nil
-        instance.config.get(:parameters, 'SnakeCasedParameter').must_equal 'value'
+        instance.config.get(:parameters, "SnakeCasedParameter").must_equal "value"
       end
 
-      it 'should match camel cased nested stack parameter' do
-        instance.locate_config_parameter_key(['nested', 'StackItem'], 'MyParameter', 'root').must_equal 'nested__StackItem__MyParameter'
-        instance.config.get(:parameters, 'nested__StackItem__MyParameter').must_equal 'value'
+      it "should match camel cased nested stack parameter" do
+        instance.locate_config_parameter_key(["nested", "StackItem"], "MyParameter", "root").must_equal "nested__StackItem__MyParameter"
+        instance.config.get(:parameters, "nested__StackItem__MyParameter").must_equal "value"
       end
 
-      it 'should match snake cased nested stack parameter when camel cased' do
-        instance.locate_config_parameter_key(['nested', 'stack_item'], 'my_parameter', 'root').must_equal 'nested__stack_item__my_parameter'
-        instance.config.get(:parameters, 'nested__StackItem__MyParameter').must_be_nil
-        instance.config.get(:parameters, 'nested__stack_item__my_parameter').must_equal 'value'
+      it "should match snake cased nested stack parameter when camel cased" do
+        instance.locate_config_parameter_key(["nested", "stack_item"], "my_parameter", "root").must_equal "nested__stack_item__my_parameter"
+        instance.config.get(:parameters, "nested__StackItem__MyParameter").must_be_nil
+        instance.config.get(:parameters, "nested__stack_item__my_parameter").must_equal "value"
       end
 
-      it 'should return composite key via arg values when not found' do
-        instance.locate_config_parameter_key(['nested', 'StackItem'], 'Unknown', 'root').must_equal 'nested__StackItem__Unknown'
+      it "should return composite key via arg values when not found" do
+        instance.locate_config_parameter_key(["nested", "StackItem"], "Unknown", "root").must_equal "nested__StackItem__Unknown"
       end
     end
   end

--- a/test/specs/command_module/template_spec.rb
+++ b/test/specs/command_module/template_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../helper'
+require_relative "../../helper"
 
 describe Sfn::CommandModule::Template do
   before do
@@ -16,23 +16,23 @@ describe Sfn::CommandModule::Template do
 
   let(:instance) { @instance ||= @template.new }
 
-  describe 'Compile time parameter merging' do
-    it 'should automatically merge items when stack name is not used' do
-      instance.arguments << 'stack-name'
-      instance.config.set(:compile_parameters, 'stack-name__Fubar', 'key1', 'value')
-      instance.config.set(:compile_parameters, 'Fubar', 'key2', 'value2')
+  describe "Compile time parameter merging" do
+    it "should automatically merge items when stack name is not used" do
+      instance.arguments << "stack-name"
+      instance.config.set(:compile_parameters, "stack-name__Fubar", "key1", "value")
+      instance.config.set(:compile_parameters, "Fubar", "key2", "value2")
       result = instance.merge_compile_time_parameters
-      result.get('stack-name__Fubar', 'key1').must_equal 'value'
-      result.get('stack-name__Fubar', 'key2').must_equal 'value2'
-      result.get('Fubar').must_be_nil
+      result.get("stack-name__Fubar", "key1").must_equal "value"
+      result.get("stack-name__Fubar", "key2").must_equal "value2"
+      result.get("Fubar").must_be_nil
     end
 
-    it 'should automatically prefix stack name when not provided' do
-      instance.arguments << 'stack-name'
-      instance.config.set(:compile_parameters, 'Fubar', 'key2', 'value2')
+    it "should automatically prefix stack name when not provided" do
+      instance.arguments << "stack-name"
+      instance.config.set(:compile_parameters, "Fubar", "key2", "value2")
       result = instance.merge_compile_time_parameters
-      result.get('stack-name__Fubar', 'key2').must_equal 'value2'
-      result.get('Fubar').must_be_nil
+      result.get("stack-name__Fubar", "key2").must_equal "value2"
+      result.get("Fubar").must_be_nil
     end
   end
 end

--- a/test/specs/config_spec.rb
+++ b/test/specs/config_spec.rb
@@ -1,10 +1,10 @@
-require_relative '../helper'
+require_relative "../helper"
 
 describe Sfn::Config do
-  describe 'Core configuration' do
-    it 'should properly coerce string value to hash' do
-      config = Sfn::Config.new(:credentials => 'key1:value1,key2:value2')
-      config[:credentials].must_equal 'key1' => 'value1', 'key2' => 'value2'
+  describe "Core configuration" do
+    it "should properly coerce string value to hash" do
+      config = Sfn::Config.new(:credentials => "key1:value1,key2:value2")
+      config[:credentials].must_equal "key1" => "value1", "key2" => "value2"
     end
   end
 end

--- a/test/specs/planner_spec.rb
+++ b/test/specs/planner_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../helper'
+require_relative "../helper"
 
 describe Sfn::Planner do
   let(:api) do
@@ -9,8 +9,8 @@ describe Sfn::Planner do
   end
   let(:default_stack_data) do
     Smash.new(
-      :id => '_TEST_ID_',
-      :name => '_TEST_NAME_',
+      :id => "_TEST_ID_",
+      :name => "_TEST_NAME_",
     )
   end
   let(:stack_data) { Smash.new }
@@ -32,7 +32,7 @@ describe Sfn::Planner do
     planner_type.new(ui, config, arguments, stack, options)
   end
 
-  it 'should raise error on plan generation' do
+  it "should raise error on plan generation" do
     -> { planner.generate_plan({}, {}) }.must_raise NotImplementedError
   end
 
@@ -46,45 +46,45 @@ describe Sfn::Planner do
     let(:planner_type) { Sfn::Planner::Aws }
 
     before do
-      api.expects(:aws_region).returns('us-west-2').at_least_once
+      api.expects(:aws_region).returns("us-west-2").at_least_once
       api.expects(:stack_reload).at_least_once
     end
 
-    it 'should return empty plan when templates are empty' do
+    it "should return empty plan when templates are empty" do
       api.expects(:stack_template_load).returns({}).at_least_once
       result = planner.generate_plan({}, {})
       result.delete(:stacks).values.map(&:values).flatten.all?(&:empty?).must_equal true
       result.values.all?(&:empty?).must_equal true
     end
 
-    describe 'Resource modification' do
+    describe "Resource modification" do
       before do
         api.expects(:data).returns({}).at_least_once
       end
 
       let(:template) do
         Smash.new(
-          'Resources' => {
-            'Ec2Instance' => {
-              'Type' => 'AWS::EC2::Instance',
-              'Properties' => {
-                'AvailabilityZone' => 'there',
-                'ImageId' => 'ack',
+          "Resources" => {
+            "Ec2Instance" => {
+              "Type" => "AWS::EC2::Instance",
+              "Properties" => {
+                "AvailabilityZone" => "there",
+                "ImageId" => "ack",
               },
             },
           },
         )
       end
 
-      it 'should flag Ec2Instance for replacement on image id' do
+      it "should flag Ec2Instance for replacement on image id" do
         api.expects(:stack_template_load).returns(
           {
-            'Resources' => {
-              'Ec2Instance' => {
-                'Type' => 'AWS::EC2::Instance',
-                'Properties' => {
-                  'AvailabilityZone' => 'there',
-                  'ImageId' => 'quack',
+            "Resources" => {
+              "Ec2Instance" => {
+                "Type" => "AWS::EC2::Instance",
+                "Properties" => {
+                  "AvailabilityZone" => "there",
+                  "ImageId" => "quack",
                 },
               },
             },
@@ -92,20 +92,20 @@ describe Sfn::Planner do
         ).at_least_once
         result = planner.generate_plan(template, {})[:stacks][stack.name]
         result[:replace].wont_be :empty?
-        result[:replace]['Ec2Instance']['name'].must_equal 'Ec2Instance'
-        result[:replace]['Ec2Instance']['type'].must_equal 'AWS::EC2::Instance'
-        result[:replace]['Ec2Instance']['properties'].must_include 'ImageId'
+        result[:replace]["Ec2Instance"]["name"].must_equal "Ec2Instance"
+        result[:replace]["Ec2Instance"]["type"].must_equal "AWS::EC2::Instance"
+        result[:replace]["Ec2Instance"]["properties"].must_include "ImageId"
       end
 
-      it 'should flag Ec2Instance for replacement' do
+      it "should flag Ec2Instance for replacement" do
         api.expects(:stack_template_load).returns(
           {
-            'Resources' => {
-              'Ec2Instance' => {
-                'Type' => 'AWS::EC2::Instance',
-                'Properties' => {
-                  'AvailabilityZone' => 'here',
-                  'ImageId' => 'ack',
+            "Resources" => {
+              "Ec2Instance" => {
+                "Type" => "AWS::EC2::Instance",
+                "Properties" => {
+                  "AvailabilityZone" => "here",
+                  "ImageId" => "ack",
                 },
               },
             },
@@ -113,31 +113,31 @@ describe Sfn::Planner do
         ).at_least_once
         result = planner.generate_plan(template, {})[:stacks][stack.name]
         result[:replace].wont_be :empty?
-        result[:replace]['Ec2Instance']['name'].must_equal 'Ec2Instance'
-        result[:replace]['Ec2Instance']['type'].must_equal 'AWS::EC2::Instance'
-        result[:replace]['Ec2Instance']['properties'].must_include 'AvailabilityZone'
+        result[:replace]["Ec2Instance"]["name"].must_equal "Ec2Instance"
+        result[:replace]["Ec2Instance"]["type"].must_equal "AWS::EC2::Instance"
+        result[:replace]["Ec2Instance"]["properties"].must_include "AvailabilityZone"
       end
     end
 
-    describe 'Resource removal' do
+    describe "Resource removal" do
       before do
         api.expects(:data).returns({}).at_least_once
       end
 
       let(:template) do
         Smash.new(
-          'Resources' => {},
+          "Resources" => {},
         )
       end
 
-      it 'should return Ec2Instance removal' do
+      it "should return Ec2Instance removal" do
         api.expects(:stack_template_load).returns(
           {
-            'Resources' => {
-              'Ec2Instance' => {
-                'Type' => 'AWS::EC2::Instance',
-                'Properties' => {
-                  'ImageId' => 'quack',
+            "Resources" => {
+              "Ec2Instance" => {
+                "Type" => "AWS::EC2::Instance",
+                "Properties" => {
+                  "ImageId" => "quack",
                 },
               },
             },
@@ -145,60 +145,60 @@ describe Sfn::Planner do
         ).at_least_once
         result = planner.generate_plan(template, {})[:stacks][stack.name]
         result[:removed].wont_be :empty?
-        result[:removed]['Ec2Instance']['name'].must_equal 'Ec2Instance'
-        result[:removed]['Ec2Instance']['type'].must_equal 'AWS::EC2::Instance'
+        result[:removed]["Ec2Instance"]["name"].must_equal "Ec2Instance"
+        result[:removed]["Ec2Instance"]["type"].must_equal "AWS::EC2::Instance"
       end
     end
 
-    describe 'Resource addition' do
+    describe "Resource addition" do
       before do
         api.expects(:data).returns({}).at_least_once
       end
 
       let(:template) do
         Smash.new(
-          'Resources' => {
-            'Ec2Instance' => {
-              'Type' => 'AWS::EC2::Instance',
-              'Properties' => {
-                'ImageId' => 'ack',
+          "Resources" => {
+            "Ec2Instance" => {
+              "Type" => "AWS::EC2::Instance",
+              "Properties" => {
+                "ImageId" => "ack",
               },
             },
           },
         )
       end
 
-      it 'should return empty plan when templates are empty' do
+      it "should return empty plan when templates are empty" do
         api.expects(:stack_template_load).returns(
           {
-            'Resources' => {},
+            "Resources" => {},
           }
         ).at_least_once
         result = planner.generate_plan(template, {})[:stacks][stack.name]
         result[:added].wont_be :empty?
-        result[:added]['Ec2Instance']['name'].must_equal 'Ec2Instance'
-        result[:added]['Ec2Instance']['type'].must_equal 'AWS::EC2::Instance'
+        result[:added]["Ec2Instance"]["name"].must_equal "Ec2Instance"
+        result[:added]["Ec2Instance"]["type"].must_equal "AWS::EC2::Instance"
       end
     end
 
-    describe 'Parameter types on update' do
+    describe "Parameter types on update" do
       before do
         api.expects(:data).returns({}).at_least_once
       end
 
       let(:template) do
         Smash.new(
-          'Parameters' => {
-            'TestParam' => {
-              'Type' => 'Number',
+          "Parameters" => {
+            "TestParam" => {
+              "Type" => "Number",
             },
           },
-          'Resources' => {
-            'Ec2Instance' => {
-              'Type' => 'AWS::EC2::Instance',
-              'Properties' => {
-                'ImageId' => {
-                  'Ref' => 'TestParam',
+          "Resources" => {
+            "Ec2Instance" => {
+              "Type" => "AWS::EC2::Instance",
+              "Properties" => {
+                "ImageId" => {
+                  "Ref" => "TestParam",
                 },
               },
             },
@@ -207,60 +207,60 @@ describe Sfn::Planner do
       end
 
       let(:stack_parameters) do
-        {'TestParam' => 1}.to_smash
+        {"TestParam" => 1}.to_smash
       end
 
-      it 'should return empty plan when parameters are different types but equivalent' do
+      it "should return empty plan when parameters are different types but equivalent" do
         api.expects(:stack_template_load).returns(
           {
-            'Parameters' => {
-              'TestParam' => {
-                'Type' => 'Number',
+            "Parameters" => {
+              "TestParam" => {
+                "Type" => "Number",
               },
             },
-            'Resources' => {
-              'Ec2Instance' => {
-                'Type' => 'AWS::EC2::Instance',
-                'Properties' => {
-                  'ImageId' => {
-                    'Ref' => 'TestParam',
+            "Resources" => {
+              "Ec2Instance" => {
+                "Type" => "AWS::EC2::Instance",
+                "Properties" => {
+                  "ImageId" => {
+                    "Ref" => "TestParam",
                   },
                 },
               },
             },
           }
         ).at_least_once
-        result = planner.generate_plan(template, {'TestParam' => '1'})[:stacks][stack.name]
+        result = planner.generate_plan(template, {"TestParam" => "1"})[:stacks][stack.name]
         result[:replace].must_be :empty?
       end
     end
 
-    describe 'Template data types within planner' do
+    describe "Template data types within planner" do
       before do
         api.expects(:data).returns({}).at_least_once
       end
 
       let(:template) do
         Smash.new(
-          'Resources' => {
-            'Ec2Instance' => {
-              'Type' => 'AWS::EC2::Instance',
-              'Properties' => {
-                'ImageId' => 100,
+          "Resources" => {
+            "Ec2Instance" => {
+              "Type" => "AWS::EC2::Instance",
+              "Properties" => {
+                "ImageId" => 100,
               },
             },
           },
         )
       end
 
-      it 'should not flag removal due to type difference' do
+      it "should not flag removal due to type difference" do
         api.expects(:stack_template_load).returns(
           {
-            'Resources' => {
-              'Ec2Instance' => {
-                'Type' => 'AWS::EC2::Instance',
-                'Properties' => {
-                  'ImageId' => '100',
+            "Resources" => {
+              "Ec2Instance" => {
+                "Type" => "AWS::EC2::Instance",
+                "Properties" => {
+                  "ImageId" => "100",
                 },
               },
             },
@@ -271,31 +271,31 @@ describe Sfn::Planner do
       end
     end
 
-    describe 'Template conditionals' do
+    describe "Template conditionals" do
       before do
         api.expects(:data).returns({}).at_least_once
       end
 
       let(:template) do
         Smash.new(
-          'Parameters' => {
-            'Enabled' => {
-              'Type' => 'String',
+          "Parameters" => {
+            "Enabled" => {
+              "Type" => "String",
             },
           },
-          'Conditions' => {
-            'IsEnabled' => {
-              'Fn::Equals' => [
-                {'Ref' => 'Enabled'}, 'yes',
+          "Conditions" => {
+            "IsEnabled" => {
+              "Fn::Equals" => [
+                {"Ref" => "Enabled"}, "yes",
               ],
             },
           },
-          'Resources' => {
-            'Ec2Instance' => {
-              'Type' => 'AWS::EC2::Instance',
-              'Properties' => {
-                'ImageId' => {
-                  'Fn::If' => ['IsEnabled', 100, 200],
+          "Resources" => {
+            "Ec2Instance" => {
+              "Type" => "AWS::EC2::Instance",
+              "Properties" => {
+                "ImageId" => {
+                  "Fn::If" => ["IsEnabled", 100, 200],
                 },
               },
             },
@@ -303,122 +303,122 @@ describe Sfn::Planner do
         )
       end
 
-      describe 'parameter does not change condition' do
+      describe "parameter does not change condition" do
         let(:stack_parameters) do
-          Smash.new('Enabled' => 'yes')
+          Smash.new("Enabled" => "yes")
         end
 
-        it 'should not flag removal' do
+        it "should not flag removal" do
           api.expects(:stack_template_load).returns(template).at_least_once
           result = planner.generate_plan(template, stack_parameters)[:stacks][stack.name]
           result[:removed].must_be :empty?
         end
       end
 
-      describe 'parameter changes condition' do
+      describe "parameter changes condition" do
         let(:stack_parameters) do
-          Smash.new('Enabled' => 'yes')
+          Smash.new("Enabled" => "yes")
         end
 
-        it 'should flag removal' do
+        it "should flag removal" do
           api.expects(:stack_template_load).returns(template).at_least_once
-          result = planner.generate_plan(template, Smash.new('Enabled' => 'no'))[:stacks][stack.name]
+          result = planner.generate_plan(template, Smash.new("Enabled" => "no"))[:stacks][stack.name]
           result[:replace].wont_be :empty?
-          result[:replace].keys.must_include 'Ec2Instance'
+          result[:replace].keys.must_include "Ec2Instance"
         end
       end
 
-      describe 'resource specific conditions' do
+      describe "resource specific conditions" do
         let(:template) do
           Smash.new(
-            'Parameters' => {
-              'Enabled' => {
-                'Type' => 'String',
+            "Parameters" => {
+              "Enabled" => {
+                "Type" => "String",
               },
             },
-            'Conditions' => {
-              'IsEnabled' => {
-                'Fn::Equals' => [
-                  {'Ref' => 'Enabled'}, 'yes',
+            "Conditions" => {
+              "IsEnabled" => {
+                "Fn::Equals" => [
+                  {"Ref" => "Enabled"}, "yes",
                 ],
               },
             },
-            'Resources' => {
-              'Ec2Instance' => {
-                'OnCondition' => 'IsEnabled',
-                'Type' => 'AWS::EC2::Instance',
-                'Properties' => {
-                  'ImageId' => 9,
+            "Resources" => {
+              "Ec2Instance" => {
+                "OnCondition" => "IsEnabled",
+                "Type" => "AWS::EC2::Instance",
+                "Properties" => {
+                  "ImageId" => 9,
                 },
               },
             },
           )
         end
 
-        describe 'parameter does not change condition' do
+        describe "parameter does not change condition" do
           let(:stack_parameters) do
-            Smash.new('Enabled' => 'yes')
+            Smash.new("Enabled" => "yes")
           end
 
-          it 'should not flag removal' do
+          it "should not flag removal" do
             api.expects(:stack_template_load).returns(template).at_least_once
             result = planner.generate_plan(template, stack_parameters)[:stacks][stack.name]
             result[:removed].must_be :empty?
           end
         end
 
-        describe 'parameter changes condition' do
+        describe "parameter changes condition" do
           let(:stack_parameters) do
-            Smash.new('Enabled' => 'yes')
+            Smash.new("Enabled" => "yes")
           end
 
-          it 'should flag removal' do
+          it "should flag removal" do
             api.expects(:stack_template_load).returns(template).at_least_once
-            result = planner.generate_plan(template, Smash.new('Enabled' => 'no'))[:stacks][stack.name]
+            result = planner.generate_plan(template, Smash.new("Enabled" => "no"))[:stacks][stack.name]
             result[:removed].wont_be :empty?
-            result[:removed].keys.must_include 'Ec2Instance'
+            result[:removed].keys.must_include "Ec2Instance"
           end
         end
       end
 
-      describe 'resource modification ref conditionals' do
+      describe "resource modification ref conditionals" do
         let(:template) do
           Smash.new(
-            'Parameters' => {
-              'NodeImageId' => {
-                'Type' => 'String',
+            "Parameters" => {
+              "NodeImageId" => {
+                "Type" => "String",
               },
             },
-            'Conditions' => {
-              'InSpecificAz' => {
-                'Fn::Equals' => [
+            "Conditions" => {
+              "InSpecificAz" => {
+                "Fn::Equals" => [
                   {
-                    'Fn::GetAtt' => [
-                      {'Ref' => 'Ec2Instance'},
-                      'AvailabilityZone',
+                    "Fn::GetAtt" => [
+                      {"Ref" => "Ec2Instance"},
+                      "AvailabilityZone",
                     ],
                   },
-                  'us-west-1',
+                  "us-west-1",
                 ],
               },
             },
-            'Resources' => {
-              'Ec2Instance' => {
-                'Type' => 'AWS::EC2::Instance',
-                'Properties' => {
-                  'ImageId' => {
-                    'Ref' => 'NodeImageId',
+            "Resources" => {
+              "Ec2Instance" => {
+                "Type" => "AWS::EC2::Instance",
+                "Properties" => {
+                  "ImageId" => {
+                    "Ref" => "NodeImageId",
                   },
                 },
               },
-              'OtherEc2Instance' => {
-                'Type' => 'AWS::EC2::Instance',
-                'Properties' => {
-                  'ImageId' => {
-                    'Fn::If' => [
-                      'InSpecificAz',
-                      {'Ref' => 'NodeImageId'},
-                      '12',
+              "OtherEc2Instance" => {
+                "Type" => "AWS::EC2::Instance",
+                "Properties" => {
+                  "ImageId" => {
+                    "Fn::If" => [
+                      "InSpecificAz",
+                      {"Ref" => "NodeImageId"},
+                      "12",
                     ],
                   },
                 },
@@ -427,28 +427,28 @@ describe Sfn::Planner do
           )
         end
 
-        describe 'when resource is not modified' do
+        describe "when resource is not modified" do
           let(:stack_parameters) do
-            Smash.new('NodeImageId' => '11')
+            Smash.new("NodeImageId" => "11")
           end
 
-          it 'should not flag removal' do
+          it "should not flag removal" do
             api.expects(:stack_template_load).returns(template).at_least_once
             result = planner.generate_plan(template, stack_parameters)[:stacks][stack.name]
             result[:removed].must_be :empty?
           end
         end
 
-        describe 'when resource is modified' do
+        describe "when resource is modified" do
           let(:stack_parameters) do
-            Smash.new('NodeImageId' => '11')
+            Smash.new("NodeImageId" => "11")
           end
 
-          it 'should flag unknown' do
+          it "should flag unknown" do
             api.expects(:stack_template_load).returns(template).at_least_once
-            result = planner.generate_plan(template, Smash.new('NodeImageId' => '22'))[:stacks][stack.name]
+            result = planner.generate_plan(template, Smash.new("NodeImageId" => "22"))[:stacks][stack.name]
             result[:unknown].wont_be :empty?
-            result[:unknown].keys.must_include 'OtherEc2Instance'
+            result[:unknown].keys.must_include "OtherEc2Instance"
           end
         end
       end

--- a/test/specs/sfn_bin_spec.rb
+++ b/test/specs/sfn_bin_spec.rb
@@ -1,6 +1,6 @@
-require_relative '../helper'
+require_relative "../helper"
 
-describe 'sfn' do
+describe "sfn" do
   def be_sh(command, options = {})
     result = `#{command} 2>&1`
     unless $?.success?
@@ -11,85 +11,85 @@ describe 'sfn' do
     result
   end
 
-  it 'shows help without arguments' do
-    be_sh('sfn', :fail => true).must_include 'Available commands:'
+  it "shows help without arguments" do
+    be_sh("sfn", :fail => true).must_include "Available commands:"
   end
 
-  it 'shows help when asking for help' do
-    be_sh('sfn --help').must_include 'Available commands:'
+  it "shows help when asking for help" do
+    be_sh("sfn --help").must_include "Available commands:"
   end
 
-  it 'shows version' do
-    be_sh('sfn --version').must_include 'SparkleFormation CLI - [Version:'
+  it "shows version" do
+    be_sh("sfn --version").must_include "SparkleFormation CLI - [Version:"
   end
 
-  it 'errors on unknown flags' do
-    -> { be_sh('sfn create --fubar') }.must_raise StandardError
-    be_sh('sfn create --fubar', :fail => true).must_include '--fubar'
+  it "errors on unknown flags" do
+    -> { be_sh("sfn create --fubar") }.must_raise StandardError
+    be_sh("sfn create --fubar", :fail => true).must_include "--fubar"
   end
 
-  it 'should include stack trace when debug flag provided' do
-    be_sh('sfn create --fubar --debug', :fail => true).must_include 'in `validate_arguments!'
+  it "should include stack trace when debug flag provided" do
+    be_sh("sfn create --fubar --debug", :fail => true).must_include "in `validate_arguments!"
   end
 
-  describe 'configuration file' do
-    let(:config_dir) { File.join(File.dirname(__FILE__), 'config') }
+  describe "configuration file" do
+    let(:config_dir) { File.join(File.dirname(__FILE__), "config") }
 
-    it 'should load configuration file with no extension' do
-      result = Dir.chdir(File.join(config_dir, 'no-ext')) do
-        be_sh('sfn conf')
+    it "should load configuration file with no extension" do
+      result = Dir.chdir(File.join(config_dir, "no-ext")) do
+        be_sh("sfn conf")
       end
       result.must_match /processing.*?:.*?false/
     end
 
-    it 'should load Ruby configuration file with extension' do
-      result = Dir.chdir(File.join(config_dir, 'ruby-ext')) do
-        be_sh('sfn conf')
+    it "should load Ruby configuration file with extension" do
+      result = Dir.chdir(File.join(config_dir, "ruby-ext")) do
+        be_sh("sfn conf")
       end
       result.must_match /processing.*?:.*?false/
     end
 
-    it 'should load YAML configuration file with extension' do
-      result = Dir.chdir(File.join(config_dir, 'yaml-ext')) do
-        be_sh('sfn conf')
+    it "should load YAML configuration file with extension" do
+      result = Dir.chdir(File.join(config_dir, "yaml-ext")) do
+        be_sh("sfn conf")
       end
       result.must_match /processing.*?:.*?false/
     end
 
-    it 'should load JSON configuration file with extension' do
-      result = Dir.chdir(File.join(config_dir, 'json-ext')) do
-        be_sh('sfn conf')
+    it "should load JSON configuration file with extension" do
+      result = Dir.chdir(File.join(config_dir, "json-ext")) do
+        be_sh("sfn conf")
       end
       result.must_match /processing.*?:.*?false/
     end
 
-    it 'should display JSON specific load error when JSON load fails' do
-      result = Dir.chdir(File.join(config_dir, 'fail-auto-json')) do
-        be_sh('sfn conf', :fail => true)
+    it "should display JSON specific load error when JSON load fails" do
+      result = Dir.chdir(File.join(config_dir, "fail-auto-json")) do
+        be_sh("sfn conf", :fail => true)
       end
-      result.must_include 'unexpected token'
+      result.must_include "unexpected token"
     end
 
-    it 'should display Ruby specific load error when Ruby load fails' do
-      result = Dir.chdir(File.join(config_dir, 'fail-auto-ruby')) do
-        be_sh('sfn conf', :fail => true)
+    it "should display Ruby specific load error when Ruby load fails" do
+      result = Dir.chdir(File.join(config_dir, "fail-auto-ruby")) do
+        be_sh("sfn conf", :fail => true)
       end
-      result.must_include 'syntax error'
+      result.must_include "syntax error"
     end
 
-    it 'should display YAML specific load error when YAML load fails' do
-      result = Dir.chdir(File.join(config_dir, 'fail-auto-yaml')) do
-        be_sh('sfn conf', :fail => true)
+    it "should display YAML specific load error when YAML load fails" do
+      result = Dir.chdir(File.join(config_dir, "fail-auto-yaml")) do
+        be_sh("sfn conf", :fail => true)
       end
-      result.must_include 'did not find expected node'
+      result.must_include "did not find expected node"
     end
 
-    it 'should display stacktrace in debug mode on load error' do
-      result = Dir.chdir(File.join(config_dir, 'fail-auto-yaml')) do
-        be_sh('sfn conf --debug', :fail => true)
+    it "should display stacktrace in debug mode on load error" do
+      result = Dir.chdir(File.join(config_dir, "fail-auto-yaml")) do
+        be_sh("sfn conf --debug", :fail => true)
       end
-      result.must_include 'Stacktrace'
-      result.must_include 'SyntaxError'
+      result.must_include "Stacktrace"
+      result.must_include "SyntaxError"
     end
   end
 end

--- a/test/specs/utils/stack_parameter_validator_spec.rb
+++ b/test/specs/utils/stack_parameter_validator_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../helper'
+require_relative "../../helper"
 
 describe Sfn::Utils::StackParameterValidator do
   let(:validator) do
@@ -7,137 +7,137 @@ describe Sfn::Utils::StackParameterValidator do
     klass.new
   end
 
-  it 'should detect list types' do
-    validator.list_type?('CommaDelimitedString').must_equal true
-    validator.list_type?('comma_delimited_string').must_equal true
-    validator.list_type?('List<String>').must_equal true
-    validator.list_type?('List<AWS::EC2::Image::Id>').must_equal true
+  it "should detect list types" do
+    validator.list_type?("CommaDelimitedString").must_equal true
+    validator.list_type?("comma_delimited_string").must_equal true
+    validator.list_type?("List<String>").must_equal true
+    validator.list_type?("List<AWS::EC2::Image::Id>").must_equal true
   end
 
-  it 'should not detect non-list types' do
-    validator.list_type?('Number').must_equal false
-    validator.list_type?('json').must_equal false
-    validator.list_type?('AWS::EC2::Image::Id').must_equal false
+  it "should not detect non-list types" do
+    validator.list_type?("Number").must_equal false
+    validator.list_type?("json").must_equal false
+    validator.list_type?("AWS::EC2::Image::Id").must_equal false
   end
 
-  it 'should reject value under min value' do
+  it "should reject value under min value" do
     validator.min_value(2, 3).wont_equal true
   end
 
-  it 'should accept value above min value' do
+  it "should accept value above min value" do
     validator.min_value(4, 3).must_equal true
   end
 
-  it 'should accept value equal to min value' do
+  it "should accept value equal to min value" do
     validator.min_value(3, 3).must_equal true
   end
 
-  it 'should reject value over max value' do
+  it "should reject value over max value" do
     validator.max_value(4, 3).wont_equal true
   end
 
-  it 'should accept value below max value' do
+  it "should accept value below max value" do
     validator.max_value(3, 4).must_equal true
   end
 
-  it 'should accept value equal to max value' do
+  it "should accept value equal to max value" do
     validator.max_value(3, 3).must_equal true
   end
 
-  it 'should reject value under min length' do
-    validator.min_length('fubar', 6).wont_equal true
+  it "should reject value under min length" do
+    validator.min_length("fubar", 6).wont_equal true
   end
 
-  it 'should accept value over min length' do
-    validator.min_length('fubar', 4).must_equal true
+  it "should accept value over min length" do
+    validator.min_length("fubar", 4).must_equal true
   end
 
-  it 'should accept value equal to min length' do
-    validator.min_length('fubar', 5).must_equal true
+  it "should accept value equal to min length" do
+    validator.min_length("fubar", 5).must_equal true
   end
 
-  it 'should reject value over max length' do
-    validator.max_length('fubar', 4).wont_equal true
+  it "should reject value over max length" do
+    validator.max_length("fubar", 4).wont_equal true
   end
 
-  it 'should accept value under max length' do
-    validator.max_length('fubar', 6).must_equal true
+  it "should accept value under max length" do
+    validator.max_length("fubar", 6).must_equal true
   end
 
-  it 'should accept value equal to max length' do
-    validator.max_length('fubar', 5).must_equal true
+  it "should accept value equal to max length" do
+    validator.max_length("fubar", 5).must_equal true
   end
 
-  it 'should reject value not matching pattern' do
-    validator.allowed_pattern('invalid-ami-9999', '^ami-\d+$').wont_equal true
+  it "should reject value not matching pattern" do
+    validator.allowed_pattern("invalid-ami-9999", '^ami-\d+$').wont_equal true
   end
 
-  it 'should accept value matching pattern' do
-    validator.allowed_pattern('ami-9999', '^ami-\d+$').must_equal true
+  it "should accept value matching pattern" do
+    validator.allowed_pattern("ami-9999", '^ami-\d+$').must_equal true
   end
 
-  it 'should reject value not defined within allowed values' do
-    validator.allowed_values('ack', ['valid1', 'valid2']).wont_equal true
+  it "should reject value not defined within allowed values" do
+    validator.allowed_values("ack", ["valid1", "valid2"]).wont_equal true
   end
 
-  it 'should accept value defined within allowed values' do
-    validator.allowed_values('ack', ['valid1', 'ack', 'valid2']).must_equal true
+  it "should accept value defined within allowed values" do
+    validator.allowed_values("ack", ["valid1", "ack", "valid2"]).must_equal true
   end
 
-  describe 'Definition validation' do
-    it 'should reject value as too long' do
-      result = validator.validate_parameter('fubar',
-                                            'MaxLength' => 4)
+  describe "Definition validation" do
+    it "should reject value as too long" do
+      result = validator.validate_parameter("fubar",
+                                            "MaxLength" => 4)
       result.wont_equal true
       result.size.must_equal 1
       result = result.first
-      result.first.must_equal 'max_length'
+      result.first.must_equal "max_length"
       result.last.must_be_kind_of String
     end
 
-    it 'should process multiple values when list' do
-      result = validator.validate_parameter('fubar,ack',
-                                            'Type' => 'CommaDelimitedList',
-                                            'MaxLength' => 4)
+    it "should process multiple values when list" do
+      result = validator.validate_parameter("fubar,ack",
+                                            "Type" => "CommaDelimitedList",
+                                            "MaxLength" => 4)
       result.wont_equal true
       result.size.must_equal 1
       result = result.first
-      result.first.must_equal 'max_length'
+      result.first.must_equal "max_length"
       result.last.must_be_kind_of String
     end
 
-    it 'should process multiple values when list and reject all' do
-      results = validator.validate_parameter('fubar,ack',
-                                             'Type' => 'CommaDelimitedList',
-                                             'MaxLength' => 2)
+    it "should process multiple values when list and reject all" do
+      results = validator.validate_parameter("fubar,ack",
+                                             "Type" => "CommaDelimitedList",
+                                             "MaxLength" => 2)
       results.wont_equal true
       results.size.must_equal 2
       results.each do |result|
-        result.first.must_equal 'max_length'
+        result.first.must_equal "max_length"
         result.last.must_be_kind_of String
       end
     end
 
-    it 'should process CFN List type' do
-      results = validator.validate_parameter('fubar,ack',
-                                             'Type' => 'List<String>',
-                                             'MaxLength' => 2)
+    it "should process CFN List type" do
+      results = validator.validate_parameter("fubar,ack",
+                                             "Type" => "List<String>",
+                                             "MaxLength" => 2)
       results.wont_equal true
       results.size.must_equal 2
       results.each do |result|
-        result.first.must_equal 'max_length'
+        result.first.must_equal "max_length"
         result.last.must_be_kind_of String
       end
     end
 
-    it 'should process HOT list type' do
-      results = validator.validate_parameter('fubar,ack',
-                                             'type' => 'comma_delimited_string',
-                                             'max_length' => 2)
+    it "should process HOT list type" do
+      results = validator.validate_parameter("fubar,ack",
+                                             "type" => "comma_delimited_string",
+                                             "max_length" => 2)
       results.wont_equal true
       results.size.must_equal 2
       results.each do |result|
-        result.first.must_equal 'max_length'
+        result.first.must_equal "max_length"
         result.last.must_be_kind_of String
       end
     end


### PR DESCRIPTION
This is a pretty simple fix.

`validate` technically already worked on any file path provided, but the name
argument passed to the validate_stack method only did a name lookup in the
collection of known templates discovered in the sparkleformation path.

Signed-off-by: Sean Escriva <sean.escriva@gmail.com>