### PR TITLE
Split plan into two commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: ruby
 rvm:
   - 2.3
   - 2.4
+  - 2.5
 script: bundle exec rake

--- a/lib/sfn.rb
+++ b/lib/sfn.rb
@@ -6,6 +6,7 @@ require "sparkle_formation"
 module Sfn
   autoload :ApiProvider, "sfn/api_provider"
   autoload :Callback, "sfn/callback"
+  autoload :Error, "sfn/error"
   autoload :Provider, "sfn/provider"
   autoload :Cache, "sfn/cache"
   autoload :Config, "sfn/config"

--- a/lib/sfn/command.rb
+++ b/lib/sfn/command.rb
@@ -21,6 +21,7 @@ module Sfn
     autoload :Plan, "sfn/command/plan"
     autoload :Print, "sfn/command/print"
     autoload :Promote, "sfn/command/promote"
+    autoload :Realize, "sfn/command/realize"
     autoload :Update, "sfn/command/update"
     autoload :Validate, "sfn/command/validate"
 

--- a/lib/sfn/command/import.rb
+++ b/lib/sfn/command/import.rb
@@ -26,7 +26,8 @@ module Sfn
               if config[:interactive_parameters]
                 answer = ui.ask_question(
                   "Import via file system (fs) or remote bucket (remote)?",
-                  :default => "remote")
+                  :default => "remote",
+                )
               else
                 answer = "remote"
               end

--- a/lib/sfn/command/import.rb
+++ b/lib/sfn/command/import.rb
@@ -23,7 +23,13 @@ module Sfn
           if entries.size > 1
             valid = false
             until valid
-              answer = ui.ask_question("Import via file system (fs) or remote bucket (remote)?", :default => "remote")
+              if config[:interactive_parameters]
+                answer = ui.ask_question(
+                  "Import via file system (fs) or remote bucket (remote)?",
+                  :default => "remote")
+              else
+                answer = "remote"
+              end
               valid = true if %w(remote fs).include?(answer)
               entries = [answer]
             end

--- a/lib/sfn/command/realize.rb
+++ b/lib/sfn/command/realize.rb
@@ -53,20 +53,20 @@ module Sfn
             if config[:poll]
               poll_stack(stack.name)
               if [:update_complete, :create_complete].
-                  include?(stack.reload.state)
+                include?(stack.reload.state)
                 ui.info "Stack plan apply complete: " \
-                  "#{ui.color("SUCCESS", :green)}"
+                        "#{ui.color("SUCCESS", :green)}"
                 namespace.const_get(:Describe).
                   new({:outputs => true}, [name]).execute!
               else
                 ui.fatal "Update of stack #{ui.color(name, :bold)}: " \
-                  "#{ui.color("FAILED", :red, :bold)}"
+                         "#{ui.color("FAILED", :red, :bold)}"
                 raise Error::StackStateIncomplete
               end
             else
               ui.warn "Stack state polling has been disabled."
               ui.info "Stack plan apply initialized for " \
-                "#{ui.color(name, :green)}"
+                      "#{ui.color(name, :green)}"
             end
           end
         rescue Miasma::Error::ApiError::RequestError => e

--- a/lib/sfn/command/realize.rb
+++ b/lib/sfn/command/realize.rb
@@ -1,0 +1,82 @@
+require "sfn"
+
+module Sfn
+  class Command
+    # Realize command
+    class Realize < Command
+      include Sfn::CommandModule::Base
+      include Sfn::CommandModule::Planning
+
+      # Run the stack realize command
+      def execute!
+        name_required!
+        name = name_args.first
+
+        stack_info = "#{ui.color("Name:", :bold)} #{name}"
+        begin
+          stack = provider.stacks.get(name)
+        rescue Miasma::Error::ApiError::RequestError
+          raise Error::StackNotFound,
+            "Failed to locate stack: #{name}"
+        end
+
+        if config[:plan_name]
+          ui.debug "Setting custom plan name - #{config[:plan_name]}"
+          # ensure custom attribute is dirty so we can modify
+          stack.custom = stack.custom.dup
+          stack.custom[:plan_name] = config[:plan_name]
+        end
+
+        ui.info " -> Loading plan information..."
+
+        plan = stack.plan
+        if plan.nil?
+          raise Error::StackPlanNotFound,
+            "Failed to locate plan for stack `#{name}`"
+        end
+
+        display_plan_information(plan)
+
+        return if config[:plan_only]
+
+        if config[:merge_api_options]
+          config.fetch(:options, Smash.new).each_pair do |key, value|
+            if stack.respond_to?("#{key}=")
+              stack.send("#{key}=", value)
+            end
+          end
+        end
+
+        begin
+          api_action!(:api_stack => stack) do
+            stack.plan_execute
+            if config[:poll]
+              poll_stack(stack.name)
+              if [:update_complete, :create_complete].
+                  include?(stack.reload.state)
+                ui.info "Stack plan apply complete: " \
+                  "#{ui.color("SUCCESS", :green)}"
+                namespace.const_get(:Describe).
+                  new({:outputs => true}, [name]).execute!
+              else
+                ui.fatal "Update of stack #{ui.color(name, :bold)}: " \
+                  "#{ui.color("FAILED", :red, :bold)}"
+                raise Error::StackStateIncomplete
+              end
+            else
+              ui.warn "Stack state polling has been disabled."
+              ui.info "Stack plan apply initialized for " \
+                "#{ui.color(name, :green)}"
+            end
+          end
+        rescue Miasma::Error::ApiError::RequestError => e
+          if e.message.downcase.include?("no updates")
+            ui.warn "No changes detected for stack (#{stack.name})"
+          else
+            raise
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -112,7 +112,7 @@ module Sfn
             end
             if config[:plan_only]
               ui.info "Plan only mode requested. Exiting."
-              exit 0
+              return
             end
           end
           stack.parameters = config_root_parameters

--- a/lib/sfn/command_module/planning.rb
+++ b/lib/sfn/command_module/planning.rb
@@ -28,7 +28,12 @@ module Sfn
           ui.info "No resources life cycle changes detected in this update!"
         end
         cmd = self.class.to_s.split("::").last.downcase
-        ui.confirm "Apply this stack #{cmd}?" unless config[:plan_only]
+        if config[:plan_apply]
+          return ui.info "Applying this stack #{cmd}..."
+        elsif config[:plan_only]
+          return
+        end
+        ui.confirm "Apply this stack #{cmd}?"
       end
 
       # Print plan information to the UI

--- a/lib/sfn/command_module/stack.rb
+++ b/lib/sfn/command_module/stack.rb
@@ -341,13 +341,13 @@ module Sfn
             if current_value && current_value.to_s != stack_value.to_s
               if config[:parameter_validation] == "default"
                 ui.warn "Nested stack has been altered directly! " \
-                  "This update may cause unexpected modifications!"
+                        "This update may cause unexpected modifications!"
                 ui.warn "Stack name: #{c_stack.name}. Parameter: #{p_key}. " \
-                  "Current value: #{stack_value}. Expected value: #{current_value} " \
-                  "(via: #{c_value.inspect})"
+                        "Current value: #{stack_value}. Expected value: #{current_value} " \
+                        "(via: #{c_value.inspect})"
                 if config[:interactive_parameters]
                   answer = ui.ask_question("Use current value or expected value for #{p_key} " \
-                    "[current/expected]?", :valid => ["current", "expected"])
+                  "[current/expected]?", :valid => ["current", "expected"])
                 else
                   raise Error::InteractionDisabled
                 end

--- a/lib/sfn/command_module/stack.rb
+++ b/lib/sfn/command_module/stack.rb
@@ -349,8 +349,7 @@ module Sfn
                   answer = ui.ask_question("Use current value or expected value for #{p_key} " \
                     "[current/expected]?", :valid => ["current", "expected"])
                 else
-                  ui.fatal "Interactive prompting is disabled"
-                  exit 1
+                  raise Error::InteractionDisabled
                 end
               else
                 answer = config[:parameter_validation]

--- a/lib/sfn/command_module/stack.rb
+++ b/lib/sfn/command_module/stack.rb
@@ -340,9 +340,18 @@ module Sfn
             end
             if current_value && current_value.to_s != stack_value.to_s
               if config[:parameter_validation] == "default"
-                ui.warn "Nested stack has been altered directly! This update may cause unexpected modifications!"
-                ui.warn "Stack name: #{c_stack.name}. Parameter: #{p_key}. Current value: #{stack_value}. Expected value: #{current_value} (via: #{c_value.inspect})"
-                answer = ui.ask_question("Use current value or expected value for #{p_key} [current/expected]?", :valid => ["current", "expected"])
+                ui.warn "Nested stack has been altered directly! " \
+                  "This update may cause unexpected modifications!"
+                ui.warn "Stack name: #{c_stack.name}. Parameter: #{p_key}. " \
+                  "Current value: #{stack_value}. Expected value: #{current_value} " \
+                  "(via: #{c_value.inspect})"
+                if config[:interactive_parameters]
+                  answer = ui.ask_question("Use current value or expected value for #{p_key} " \
+                    "[current/expected]?", :valid => ["current", "expected"])
+                else
+                  ui.fatal "Interactive prompting is disabled"
+                  exit 1
+                end
               else
                 answer = config[:parameter_validation]
               end

--- a/lib/sfn/command_module/template.rb
+++ b/lib/sfn/command_module/template.rb
@@ -591,8 +591,7 @@ module Sfn
             if config[:interactive_parameters]
               response = ui.ask_question("Enter selection").to_i
             else
-              ui.fatal "Interactive prompting is disabled"
-              exit 1
+              raise Error::InteractionDisabled
             end
           end
           entry = valid[response]

--- a/lib/sfn/command_module/template.rb
+++ b/lib/sfn/command_module/template.rb
@@ -588,7 +588,12 @@ module Sfn
           ui.puts "#{output.join("\n")}\n"
           response = nil
           until valid[response]
-            response = ui.ask_question("Enter selection").to_i
+            if config[:interactive_parameters]
+              response = ui.ask_question("Enter selection").to_i
+            else
+              ui.fatal "Interactive prompting is disabled"
+              exit 1
+            end
           end
           entry = valid[response]
           if entry[:type] == :collection

--- a/lib/sfn/config.rb
+++ b/lib/sfn/config.rb
@@ -38,7 +38,9 @@ module Sfn
     end
 
     # Only values allowed designating bool type
-    BOOLEAN = BOOLEAN_VALUES = [TrueClass, FalseClass]
+    BOOLEAN = BOOLEAN_VALUES = [TrueClass, FalseClass].freeze
+    # Boolean type with nil included
+    TRISTATE_BOOLEAN = (BOOLEAN + [NilClass]).freeze
 
     autoload :Conf, "sfn/config/conf"
     autoload :Create, "sfn/config/create"
@@ -57,6 +59,7 @@ module Sfn
     autoload :Plan, "sfn/config/plan"
     autoload :Print, "sfn/config/print"
     autoload :Promote, "sfn/config/promote"
+    autoload :Realize, "sfn/config/realize"
     autoload :Update, "sfn/config/update"
     autoload :Validate, "sfn/config/validate"
 

--- a/lib/sfn/config.rb
+++ b/lib/sfn/config.rb
@@ -108,6 +108,11 @@ module Sfn
       :short_flag => "u",
     )
     attribute(
+      :log, String,
+      :description => "Enable logging with given level",
+      :short_flag => "G",
+    )
+    attribute(
       :colors, [TrueClass, FalseClass],
       :description => "Enable colorized output",
       :default => true,

--- a/lib/sfn/config/plan.rb
+++ b/lib/sfn/config/plan.rb
@@ -18,6 +18,24 @@ module Sfn
       )
 
       attribute(
+        :load_existing, TRISTATE_BOOLEAN,
+        :description => "Load existing plan if exists",
+        :default => nil
+      )
+
+      attribute(
+        :auto_destroy_stack, TRISTATE_BOOLEAN,
+        :description => "Automatically destroy empty stack",
+        :default => nil
+      )
+
+      attribute(
+        :auto_destroy_plan, TRISTATE_BOOLEAN,
+        :description => "Automatically destroy generated plan",
+        :default => nil
+      )
+
+      attribute(
         :list, BOOLEAN,
         :description => "List all available plans for stack",
         :default => false,

--- a/lib/sfn/config/plan.rb
+++ b/lib/sfn/config/plan.rb
@@ -20,19 +20,19 @@ module Sfn
       attribute(
         :load_existing, TRISTATE_BOOLEAN,
         :description => "Load existing plan if exists",
-        :default => nil
+        :default => nil,
       )
 
       attribute(
         :auto_destroy_stack, TRISTATE_BOOLEAN,
         :description => "Automatically destroy empty stack",
-        :default => nil
+        :default => nil,
       )
 
       attribute(
         :auto_destroy_plan, TRISTATE_BOOLEAN,
         :description => "Automatically destroy generated plan",
-        :default => nil
+        :default => nil,
       )
 
       attribute(

--- a/lib/sfn/config/realize.rb
+++ b/lib/sfn/config/realize.rb
@@ -1,0 +1,13 @@
+require "sfn"
+
+module Sfn
+  class Config
+    # Realize command configuration
+    class Realize < Config
+      attribute(
+        :plan_name, String,
+        :description => "Custom plan name or ID",
+      )
+    end
+  end
+end

--- a/lib/sfn/error.rb
+++ b/lib/sfn/error.rb
@@ -8,14 +8,14 @@ module Sfn
     # Exit code used when no custom code provided
     DEFAULT_EXIT_CODE = 1
 
-    def self.exit_code(c=nil)
+    def self.exit_code(c = nil)
       if c || !defined?(@exit_code)
         @exit_code = c.to_i != 0 ? c : DEFAULT_EXIT_CODE
       end
       @exit_code
     end
 
-    def self.error_msg(m=nil)
+    def self.error_msg(m = nil)
       if m || !defined?(@error_msg)
         @error_msg = m
       end
@@ -23,7 +23,7 @@ module Sfn
     end
 
     def initialize(*args)
-      opts = args.detect{ |a| a.is_a?(Hash) } || {}
+      opts = args.detect { |a| a.is_a?(Hash) } || {}
       opts = opts.to_smash
       msg = args.first.is_a?(String) ? args.first : self.class.error_msg
       super(msg)
@@ -33,7 +33,7 @@ module Sfn
           @original = opts[:original]
         else
           raise TypeError.new "Expected `Exception` type in `:original` " \
-            "option but received `#{opts[:original].class}`"
+                              "option but received `#{opts[:original].class}`"
         end
       end
     end

--- a/lib/sfn/error.rb
+++ b/lib/sfn/error.rb
@@ -1,0 +1,61 @@
+module Sfn
+  class Error < StandardError
+    # @return [Integer] exit code to report
+    attr_reader :exit_code
+    # @return [Exception, nil] original exception
+    attr_reader :original
+
+    # Exit code used when no custom code provided
+    DEFAULT_EXIT_CODE = 1
+
+    def self.exit_code(c=nil)
+      if c || !defined?(@exit_code)
+        @exit_code = c.to_i != 0 ? c : DEFAULT_EXIT_CODE
+      end
+      @exit_code
+    end
+
+    def self.error_msg(m=nil)
+      if m || !defined?(@error_msg)
+        @error_msg = m
+      end
+      @error_msg
+    end
+
+    def initialize(*args)
+      opts = args.detect{ |a| a.is_a?(Hash) } || {}
+      opts = opts.to_smash
+      msg = args.first.is_a?(String) ? args.first : self.class.error_msg
+      super(msg)
+      @exit_code = opts.fetch(:exit_code, self.class.exit_code).to_i
+      if opts[:original]
+        if opts[:original].is_a?(Exception)
+          @original = opts[:original]
+        else
+          raise TypeError.new "Expected `Exception` type in `:original` " \
+            "option but received `#{opts[:original].class}`"
+        end
+      end
+    end
+
+    class InteractionDisabled < Error
+      error_msg "Interactive prompting is disabled"
+      exit_code 2
+    end
+
+    class StackNotFound < Error
+      error_msg "Failed to locate requested stack"
+      exit_code 3
+    end
+
+    class StackPlanNotFound < Error
+      error_msg "Failed to locate requested stack plan"
+      exit_code 4
+    end
+
+    class StackStateIncomplete < Error
+      error_msg "Stack did not reach a successful completion state"
+      exit_code 5
+    end
+  end
+end


### PR DESCRIPTION
Split the `plan` command into two separate commands: `plan` and `realize`. The `plan` command still supports realizing generated plan in one step.