### PR TITLE
Add test case for `NoMethodError` crash in diff_init

### DIFF
--- a/lib/sfn/planner/aws.rb
+++ b/lib/sfn/planner/aws.rb
@@ -512,10 +512,10 @@ module Sfn
       def diff_init(diff, path)
         Smash.new.tap do |di|
           if diff.size > 1
-            updated = diff.detect { |x| x.first == "+" }
-            original = diff.detect { |x| x.first == "-" }
-            di[:original] = Array(original).last.to_s
-            di[:updated] = Array(updated).last.to_s
+            updated = diff.find_all { |x| x.first == "+" }
+            original = diff.find_all { |x| x.first == "-" }
+            di[:original] = Array(original).map(&:last).join(", ")
+            di[:updated] = Array(updated).map(&:last).join(", ")
           else
             diff_data = diff.first
             di[:path] = path

--- a/lib/sfn/planner/aws.rb
+++ b/lib/sfn/planner/aws.rb
@@ -514,8 +514,8 @@ module Sfn
           if diff.size > 1
             updated = diff.detect { |x| x.first == "+" }
             original = diff.detect { |x| x.first == "-" }
-            di[:original] = original.last.to_s
-            di[:updated] = updated.last.to_s
+            di[:original] = Array(original).last.to_s
+            di[:updated] = Array(updated).last.to_s
           else
             diff_data = diff.first
             di[:path] = path

--- a/test/specs/planner_spec.rb
+++ b/test/specs/planner_spec.rb
@@ -449,5 +449,42 @@ describe Sfn::Planner do
         end
       end
     end
+
+    describe "Parameters AllowedValues" do
+      before do
+        api.expects(:data).returns({}).at_least_once
+      end
+
+      let(:template) do
+        Smash.new(
+          "Parameters" => {
+            "Param" => {
+              "Type" => "String",
+              "AllowedValues" => ["1", "5", "4", "2", "3"], # XXX: The order is significant.
+            },
+          },
+        )
+      end
+
+      describe "AllowedValues have a different order" do
+        let(:stack_parameters) do
+          Smash.new("Param" => "1")
+        end
+
+        it "does not crash with: NoMethodError: undefined method `last' for nil:NilClass" do
+          api.expects(:stack_template_load).returns(
+            Smash.new(
+              "Parameters" => {
+                "Param" => {
+                  "Type" => "String",
+                  "AllowedValues" => ["2", "4", "1", "3", "5"], # XXX: The order is significant.
+                },
+              },
+            )
+          ).at_least_once
+          result = planner.generate_plan(template, Smash.new("Param" => "2")).stacks[stack.name]
+        end
+      end
+    end
   end
 end

--- a/test/specs/planner_spec.rb
+++ b/test/specs/planner_spec.rb
@@ -451,10 +451,6 @@ describe Sfn::Planner do
     end
 
     describe "Parameters AllowedValues" do
-      before do
-        api.expects(:data).returns({}).at_least_once
-      end
-
       let(:template) do
         Smash.new(
           "Parameters" => {


### PR DESCRIPTION
The stack trace of the error:

```
NoMethodError: undefined method `last' for nil:NilClass
    /home/dualbus/src/sparkleformation/sfn/lib/sfn/planner/aws.rb:518:in `block in diff_init'
    /home/dualbus/src/sparkleformation/sfn/lib/sfn/planner/aws.rb:513:in `tap'
    /home/dualbus/src/sparkleformation/sfn/lib/sfn/planner/aws.rb:513:in `diff_init'
    /home/dualbus/src/sparkleformation/sfn/lib/sfn/planner/aws.rb:541:in `register_diff'
    /home/dualbus/src/sparkleformation/sfn/lib/sfn/planner/aws.rb:447:in `block in run_stack_diff'
    /home/dualbus/src/sparkleformation/sfn/lib/sfn/planner/aws.rb:446:in `each'
    /home/dualbus/src/sparkleformation/sfn/lib/sfn/planner/aws.rb:446:in `run_stack_diff'
    /home/dualbus/src/sparkleformation/sfn/lib/sfn/planner/aws.rb:374:in `plan_stack'
    /home/dualbus/src/sparkleformation/sfn/lib/sfn/planner/aws.rb:252:in `generate_plan'
    /home/dualbus/src/sparkleformation/sfn/test/specs/planner_spec.rb:485:in `block (5 levels) in <top (required)>'
    /usr/lib/ruby/vendor_ruby/minitest/test.rb:98:in `block (3 levels) in run'
    /usr/lib/ruby/vendor_ruby/minitest/test.rb:195:in `capture_exceptions'
    /usr/lib/ruby/vendor_ruby/minitest/test.rb:95:in `block (2 levels) in run'
    /usr/lib/ruby/vendor_ruby/minitest.rb:265:in `time_it'
    /usr/lib/ruby/vendor_ruby/minitest/test.rb:94:in `block in run'
    /usr/lib/ruby/vendor_ruby/minitest.rb:360:in `on_signal'
    /usr/lib/ruby/vendor_ruby/minitest/test.rb:211:in `with_info_handler'
    /usr/lib/ruby/vendor_ruby/minitest/test.rb:93:in `run'
    /usr/lib/ruby/vendor_ruby/minitest.rb:960:in `run_one_method'
    /usr/lib/ruby/vendor_ruby/minitest.rb:334:in `run_one_method'
    /usr/lib/ruby/vendor_ruby/minitest.rb:321:in `block (2 levels) in run'
    /usr/lib/ruby/vendor_ruby/minitest.rb:320:in `each'
    /usr/lib/ruby/vendor_ruby/minitest.rb:320:in `block in run'
    /usr/lib/ruby/vendor_ruby/minitest.rb:360:in `on_signal'
    /usr/lib/ruby/vendor_ruby/minitest.rb:347:in `with_info_handler'
    /usr/lib/ruby/vendor_ruby/minitest.rb:319:in `run'
    /usr/lib/ruby/vendor_ruby/minitest.rb:159:in `block in __run'
    /usr/lib/ruby/vendor_ruby/minitest.rb:159:in `map'
    /usr/lib/ruby/vendor_ruby/minitest.rb:159:in `__run'
    /usr/lib/ruby/vendor_ruby/minitest.rb:136:in `run'
    /usr/lib/ruby/vendor_ruby/minitest.rb:63:in `block in autorun'
```