### PR TITLE
bug: plan did not capture options passed into .sfn.rb

### DIFF
--- a/lib/sfn/command/plan.rb
+++ b/lib/sfn/command/plan.rb
@@ -125,6 +125,13 @@ module Sfn
           end
 
           # Set options defined within config into stack instance for update request
+          if config[:merge_api_options]
+            config.fetch(:options, Smash.new).each_pair do |key, value|
+              if stack.respond_to?("#{key}=")
+                stack.send("#{key}=", value)
+              end
+            end
+          end
 
           ui.info "  -> Generating plan information..."
         else


### PR DESCRIPTION
Description:

In my `.sfn.rb`, I have set an option capabilities 
```
Configuration.new do
  options do
    capabilities ['CAPABILITY_IAM']
  end
end
```

When I executed `rake sfn:plan`, I get the following error message showing I'm missing the capabilities option even though I have it set in `.sfn.rb`
```
[ERROR]: Bad Request - InsufficientCapabilitiesException: Requires capabilities : [CAPABILITY_IAM]
```

This is because `plan.rb` did not capture any options set in `.sfn.rb` so that's why I get the bad request with missing capabilities error.

Fix is to capture options defined in `.sfn.rb` and `sfn:plan` works.

/cc @chrisroberts 
