### PR TITLE
Display stack fetch request errors

### DIFF
--- a/lib/sfn/command/diff.rb
+++ b/lib/sfn/command/diff.rb
@@ -17,7 +17,8 @@ module Sfn
 
         begin
           stack = provider.stack(name)
-        rescue Miasma::Error::ApiError::RequestError
+        rescue Miasma::Error::ApiError::RequestError => error
+          ui.error error.message unless error.response.code == 404
           stack = nil
         end
 

--- a/lib/sfn/command/plan.rb
+++ b/lib/sfn/command/plan.rb
@@ -17,7 +17,8 @@ module Sfn
         stack_info = "#{ui.color("Name:", :bold)} #{name}"
         begin
           stack = provider.stacks.get(name)
-        rescue Miasma::Error::ApiError::RequestError
+        rescue Miasma::Error::ApiError::RequestError => error
+          ui.error error.message unless error.response.code == 404
           stack = provider.stacks.build(name: name)
         end
 

--- a/lib/sfn/command/realize.rb
+++ b/lib/sfn/command/realize.rb
@@ -15,7 +15,8 @@ module Sfn
         stack_info = "#{ui.color("Name:", :bold)} #{name}"
         begin
           stack = provider.stacks.get(name)
-        rescue Miasma::Error::ApiError::RequestError
+        rescue Miasma::Error::ApiError::RequestError => error
+          ui.error error.message unless error.response.code == 404
           raise Error::StackNotFound,
             "Failed to locate stack: #{name}"
         end

--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -17,7 +17,8 @@ module Sfn
         stack_info = "#{ui.color("Name:", :bold)} #{name}"
         begin
           stack = provider.stacks.get(name)
-        rescue Miasma::Error::ApiError::RequestError
+        rescue Miasma::Error::ApiError::RequestError => error
+          ui.error error.message unless error.response.code == 404
           stack = nil
         end
 


### PR DESCRIPTION
Currently, a stack diff/update can fail with cryptic "Failed to locate requested stack" without telling you why it could not be found. This will print the error in the UI when it is not a simple not found error (e.g. permission denied etc.)

Example output:
```
[ERROR]: Forbidden - AccessDenied: User: arn:aws:sts::12345:assumed-role/myuser is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::12345:role/myrole
[FATAL]: Failed to locate requested stack: my-stack-name
```