### PR TITLE
Upgrade hashdiff gem to version 1

### DIFF
--- a/lib/sfn/command/diff.rb
+++ b/lib/sfn/command/diff.rb
@@ -56,7 +56,7 @@ module Sfn
 
         ui.info "#{ui.color("Stack diff:", :bold)} #{ui.color((parent_names + [stack.data.fetch(:logical_id, stack.name)]).compact.join(" > "), :blue)}"
 
-        stack_diff = HashDiff.diff(stack.template, file)
+        stack_diff = Hashdiff.diff(stack.template, file)
 
         if config[:raw_diff]
           ui.info "Dumping raw template diff:"

--- a/lib/sfn/planner/aws.rb
+++ b/lib/sfn/planner/aws.rb
@@ -441,7 +441,7 @@ module Sfn
           plan_results[:replace].keys + plan_results[:unavailable].keys
         )
 
-        HashDiff.diff(origin_template, MultiJson.load(MultiJson.dump(update_template))).group_by do |item|
+        Hashdiff.diff(origin_template, MultiJson.load(MultiJson.dump(update_template))).group_by do |item|
           item[1]
         end.each do |a_path, diff_items|
           register_diff(

--- a/sfn.gemspec
+++ b/sfn.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "jmespath"
   s.add_runtime_dependency "net-ssh"
   s.add_runtime_dependency "sparkle_formation", ">= 3.0.39", "< 4"
-  s.add_runtime_dependency "hashdiff", "~> 0.2.2"
+  s.add_runtime_dependency "hashdiff", "~> 1"
   s.add_runtime_dependency "graph", "~> 2.8.1"
   s.add_development_dependency "rake", "~> 10"
   s.add_development_dependency "minitest"


### PR DESCRIPTION
I'm struggling to get `sfn` into a `Gemfile` that has the latest version of `hashdiff`.

It'd be great to get `sfn` onto this latest version.