### PR TITLE
Require new mocha minitest file

### DIFF
--- a/sfn.gemspec
+++ b/sfn.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest"
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "rufo", "~> 0.3.0"
-  s.add_development_dependency "mocha"
+  s.add_development_dependency "mocha", ">= 1.4"
   s.add_development_dependency "yard"
   s.executables << "sfn"
   s.files = Dir["{lib,bin,docs}/**/*"] + %w(sfn.gemspec README.md CHANGELOG.md LICENSE)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,7 @@
 require "sfn"
 require "bogo-ui"
 require "minitest/autorun"
-require "mocha/mini_test"
+require "mocha/minitest"
 require "tempfile"
 require "openssl"
 


### PR DESCRIPTION
As changed in [mocha version 1.4.0](https://github.com/freerange/mocha/blob/master/RELEASE.md#140).

This fixes the broken build.