### PR TITLE
Tagging Support via CLI Parameter

### DIFF
--- a/lib/sfn/command/create.rb
+++ b/lib/sfn/command/create.rb
@@ -44,7 +44,8 @@ module Sfn
             :name => name,
             :template => template_content(file),
             :parameters => Smash.new,
-          )
+            :tags => config.fetch(:tags, Smash.new),
+          ) { |key, oldval, newval| oldval.respond_to?(:merge) ? oldval.merge(newval) : newval}
         )
 
         apply_stacks!(stack)

--- a/lib/sfn/command/create.rb
+++ b/lib/sfn/command/create.rb
@@ -45,7 +45,7 @@ module Sfn
             :template => template_content(file),
             :parameters => Smash.new,
             :tags => config.fetch(:tags, Smash.new),
-          ) { |key, oldval, newval| oldval.respond_to?(:merge) ? oldval.merge(newval) : newval}
+          ) { |key, oldval, newval| oldval.respond_to?(:merge) ? oldval.merge(newval) : newval }
         )
 
         apply_stacks!(stack)

--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -75,6 +75,10 @@ module Sfn
         unless config[:print_only]
           ui.info "  -> #{stack_info}"
         end
+
+        original_tags = stack.tags
+        stack.tags = original_tags.merge(config.fetch(:tags, Smash.new))
+
         if file
           if config[:print_only]
             ui.puts format_json(parameter_scrub!(template_content(file)))

--- a/lib/sfn/config/update.rb
+++ b/lib/sfn/config/update.rb
@@ -38,6 +38,10 @@ module Sfn
         :short_flag => "m",
       )
       attribute(
+        :tags, Smash,
+        :description => "Pass template tags directly",
+      )
+      attribute(
         :plan, [TrueClass, FalseClass],
         :default => true,
         :description => "Provide planning information prior to update",


### PR DESCRIPTION
Adds the ability to do a --tags on create or update of stacks. Merges correctly with existing option in .sfn and adds, overrides and keeps on exisiting stacks in the way, that at least to me seems logical.
@chrisroberts  If you feel we should change something, we are open to it. I tried to understand the code base, but I have never added anything here, but it indeed does what we want it to do. And not just we, it solves #16, though we made it based on --parameters a single option to contain all the tags.
We tested it with multiple tags in both .sfn and --tags as well. Syntax is like --parameters a Key:Value,OtherKey:OtherValue as well of course.

