### PR TITLE
fix: sfn update to use template file for applying stack

### DIFF
--- a/lib/sfn/command/update.rb
+++ b/lib/sfn/command/update.rb
@@ -84,9 +84,19 @@ module Sfn
           original_template = stack.template
           original_parameters = stack.parameters
 
-          apply_stacks!(stack)
+          # Load the template file which might have new parameters
+          stack_update = provider.connection.stacks.build(
+            config.fetch(:options, Smash.new).dup.merge(
+              :name => name,
+              :template => template_content(file),
+              :parameters => Smash.new,
+            )
+          )
+          # Apply provider stack outputs to the receiver stack(stack_update) parameters
+          apply_stacks!(stack_update)
 
-          populate_parameters!(file, :current_parameters => stack.root_parameters)
+          populate_parameters!(file, :current_parameters => stack_update.parameters)
+
           update_template = stack.template
 
           if config[:plan]


### PR DESCRIPTION
Fixes https://github.com/sparkleformation/sfn/issues/310
When updating stack introduces a new parameter, although it's in output of `--apply-stack`, current `sfn update` prompts user input for the parameter. It's because `populate_parameters` function checks for the current stack's template, not the given template file.

(I've added additional loggings for debugging purposes)
Without this fix, it's prompting user input for `SsmStopRoleArn2` because `receiver_stack (sfn-stack-2) valid_parameters` didn't check the newly given template's parameters. 
```
$ sfn update --defaults --yes sfn-stack-2 --apply-stack sfn-stack-1 --file ./template2.json
[Sfn]: SparkleFormation: update
[Sfn]:   -> Name: sfn-stack-2 Path: ./template2.json
[Sfn]: apply_stacks - remote_stacks ["sfn-stack-1"]
[Sfn]: execute_apply_stack 
receiver_stack (sfn-stack-2) valid_parameters: ["SsmStopRoleArn1"]
providing_stack (sfn-stack-1) outputs: SsmStopRoleArn2 arn:aws:iam::123412341234:role/SSM_Stop_RDS_rds-test2
providing_stack (sfn-stack-1) outputs: SsmStopRoleArn1 arn:aws:iam::123412341234:role/SSM_Stop_RDS_rds-test
[Sfn]: after apply - stack.parameters {}
[Sfn]: Stack runtime parameters:
[Sfn]: Ssm Stop Role Arn2: 
```

With this fix, `receiver_stack (sfn-stack-2) valid_parameters` detects the newly introduced parameter, and it applies the value from the outputs. 
```
$ sfn update --defaults --yes sfn-stack-2 --apply-stack sfn-stack-1 --file ./template2.json
[Sfn]: SparkleFormation: update
[Sfn]:   -> Name: sfn-stack-2 Path: ./template2.json
[Sfn]: apply_stacks - remote_stacks ["sfn-stack-1"]
[Sfn]: execute_apply_stack 
receiver_stack (sfn-stack-2) valid_parameters: ["SsmStopRoleArn1", "SsmStopRoleArn2"]
providing_stack (sfn-stack-1) outputs: SsmStopRoleArn2 arn:aws:iam::123412341234:role/SSM_Stop_RDS_rds-test2
providing_stack (sfn-stack-1) outputs: SsmStopRoleArn1 arn:aws:iam::123412341234:role/SSM_Stop_RDS_rds-test
[Sfn]: after apply - stack_update.parameters {"SsmStopRoleArn2"=>"arn:aws:iam::123412341234:role/SSM_Stop_RDS_rds-test2", "SsmStopRoleArn1"=>"arn:aws:iam::123412341234:role/SSM_Stop_RDS_rds-test"}
[Sfn]: Stack runtime parameters:
[Sfn]: Pre-update resource planning report:

  Update plan for: sfn-stack-2
    No resource lifecycle changes detected!

[Sfn]: Events for Stack: sfn-stack-2
Time                        Resource Logical Id   Resource Status      Resource Status Reason   
2023-10-20 12:11:49 -0400   sfn-stack-2           UPDATE_IN_PROGRESS   User Initiated           
2023-10-20 12:11:53 -0400   KeepRDSStopped1       UPDATE_IN_PROGRESS                                             
2023-10-20 12:11:54 -0400   KeepRDSStopped1       UPDATE_COMPLETE                                                
2023-10-20 12:11:57 -0400   sfn-stack-2           UPDATE_COMPLETE_CLEANUP_IN_PROGRESS                            
2023-10-20 12:11:58 -0400   sfn-stack-2           UPDATE_COMPLETE                                                
[Sfn]: Stack update complete: SUCCESS
```

